### PR TITLE
feat: new component LikeBox

### DIFF
--- a/src/components/Button/ButtonBox.css
+++ b/src/components/Button/ButtonBox.css
@@ -1,0 +1,43 @@
+.ui.button.button-box.icon {
+  padding: 9px 0;
+  box-sizing: border-box;
+  border-radius: 5px;
+  width: 71px;
+  height: 60px;
+  min-width: 60px;
+  border: 1px solid var(--secondary);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.ui.button.button-box.icon:hover {
+  border-color: var(--primary);
+}
+
+.ui.button.button-box.icon .icon {
+  font-size: 18px;
+  color: var(--primary);
+}
+
+.ui.button.button-box.icon .button-box__icon-hovered {
+  display: none;
+}
+
+.ui.button.button-box.icon:hover .button-box__icon {
+  display: none;
+}
+.ui.button.button-box.icon:hover .button-box__icon-hovered {
+  display: inline-block;
+}
+
+.ui.button.button-box.icon .ui.label {
+  margin: 0;
+  background-color: transparent;
+  text-transform: capitalize;
+}
+
+.ui.button.button-box.icon.loading .ui.label,
+.ui.button.button-box.icon.loading .button-box__icon {
+  display: none;
+}

--- a/src/components/Button/LikeBox.tsx
+++ b/src/components/Button/LikeBox.tsx
@@ -1,0 +1,41 @@
+import React from "react"
+
+import { Button } from "decentraland-ui/dist/components/Button/Button"
+import Icon from "semantic-ui-react/dist/commonjs/elements/Icon"
+import Label from "semantic-ui-react/dist/commonjs/elements/Label"
+
+import shorterNumber from "../../utils/number/sortenNumber"
+
+import "./ButtonBox.css"
+
+export type LikeBoxProps = {
+  total: number
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
+  loading?: boolean
+  active?: boolean
+}
+
+export default React.memo(function LikeBox(props: LikeBoxProps) {
+  const { onClick, loading, active, total } = props
+  return (
+    <Button
+      secondary
+      onClick={onClick}
+      className="button-box icon"
+      target="_blank"
+      loading={loading}
+      disabled={loading}
+    >
+      <Icon
+        name="thumbs up outline"
+        className={active ? "button-box__icon" : "button-box__icon-hovered"}
+      />
+
+      <Icon
+        name="thumbs up"
+        className={!active ? "button-box__icon" : "button-box__icon-hovered"}
+      />
+      <Label>{shorterNumber(total)}</Label>
+    </Button>
+  )
+})

--- a/src/utils/number/sortenNumber.test.ts
+++ b/src/utils/number/sortenNumber.test.ts
@@ -1,0 +1,25 @@
+import shorterNumber from "../../utils/number/sortenNumber"
+
+describe("Sorten Number", () => {
+  test(`With 100`, () => {
+    expect(shorterNumber(100)).toBe("100")
+  })
+  test(`With 1.000`, () => {
+    expect(shorterNumber(1000)).toBe("1k")
+  })
+  test(`With 1.000.000`, () => {
+    expect(shorterNumber(1000000)).toBe("1M")
+  })
+  test(`With 1.000.000.000`, () => {
+    expect(shorterNumber(1000000000)).toBe("1G")
+  })
+  test(`With 1.000.000.000.000`, () => {
+    expect(shorterNumber(1000000000000)).toBe("1T")
+  })
+  test(`With 1.000.000.000.000.000`, () => {
+    expect(shorterNumber(1000000000000000)).toBe("1P")
+  })
+  test(`With 1.000.000.000.000.000.000`, () => {
+    expect(shorterNumber(1000000000000000000)).toBe("1E")
+  })
+})

--- a/src/utils/number/sortenNumber.ts
+++ b/src/utils/number/sortenNumber.ts
@@ -1,0 +1,23 @@
+function shorterNumber(num: number, digits?: number) {
+  const lookup = [
+    { value: 1, symbol: "" },
+    { value: 1e3, symbol: "k" },
+    { value: 1e6, symbol: "M" },
+    { value: 1e9, symbol: "G" },
+    { value: 1e12, symbol: "T" },
+    { value: 1e15, symbol: "P" },
+    { value: 1e18, symbol: "E" },
+  ]
+  const rx = /\.0+$|(\.[0-9]*[1-9])0+$/
+  const item = lookup
+    .slice()
+    .reverse()
+    .find(function (item) {
+      return num >= item.value
+    })
+  return item
+    ? (num / item.value).toFixed(digits || 2).replace(rx, "$1") + item.symbol
+    : "0"
+}
+
+export default shorterNumber


### PR DESCRIPTION
Examples 
<img width="543" alt="Screen Shot 2022-09-06 at 20 14 07" src="https://user-images.githubusercontent.com/6572776/188756478-b5228bbc-e4af-4f35-9270-8344a72eed34.png">

With hover
<img width="540" alt="Screen Shot 2022-09-06 at 20 14 46" src="https://user-images.githubusercontent.com/6572776/188756498-76d06aad-3084-4bd1-abfd-fb9f173bbae9.png">

TO BE CONFIRM:
icon used here from semantic-ui, not the same as the template
<img width="119" alt="Screen Shot 2022-09-06 at 20 18 24" src="https://user-images.githubusercontent.com/6572776/188756595-dfebe81e-c8a1-4414-a812-7118e9c6ea4f.png">
