### PR TITLE
feat: Add show more button instead of pagination

### DIFF
--- a/src/__data__/entities.ts
+++ b/src/__data__/entities.ts
@@ -447,7 +447,8 @@ export const placeGenesisPlaza: PlaceAttributes = {
   world: false,
   world_name: null,
   title: "Genesis Plaza",
-  description: null,
+  description:
+    "Jump in to strike up a chat with other visitors, retake the commands tutorial with a cute floating robot, or dive into the swirling portal to get to Decentraland's visitor center.",
   owner: null,
   image: "https://decentraland.org/images/thumbnail/genesis-plaza.png",
   tags: ["plaza"],
@@ -3610,6 +3611,8 @@ export const entitySceneGenesisPlaza: ContentEntityScene & { id: string } = {
   metadata: {
     display: {
       title: "Genesis Plaza",
+      description:
+        "Jump in to strike up a chat with other visitors, retake the commands tutorial with a cute floating robot, or dive into the swirling portal to get to Decentraland's visitor center.",
       favicon: "favicon_asset",
       navmapThumbnail:
         "https://decentraland.org/images/thumbnail/genesis-plaza.png",
@@ -6880,6 +6883,8 @@ export const contentEntitySceneGenesisPlaza: ContentEntityScene = {
   metadata: {
     display: {
       title: "Genesis Plaza",
+      description:
+        "Jump in to strike up a chat with other visitors, retake the commands tutorial with a cute floating robot, or dive into the swirling portal to get to Decentraland's visitor center.",
       favicon: "favicon_asset",
       navmapThumbnail:
         "https://decentraland.org/images/thumbnail/genesis-plaza.png",

--- a/src/entities/Place/migration.test.ts
+++ b/src/entities/Place/migration.test.ts
@@ -69,13 +69,12 @@ describe("createPlaceFromEntityScene", () => {
       base_position: "-9,-9",
       featured: true,
     })
-    expect(place).toEqual({
+    expect({ ...place, deployed_at: placeGenesisPlaza.deployed_at }).toEqual({
       ...placeGenesisPlaza,
       id: place.id,
       featured: true,
       created_at: place.created_at,
       updated_at: place.updated_at,
-      deployed_at: place.deployed_at,
       featured_image: place.featured_image,
       highlighted_image: place.highlighted_image,
     })
@@ -97,14 +96,13 @@ describe("createPlaceFromEntityScene", () => {
         featured: true,
       }
     )
-    expect(place).toEqual({
+    expect({ ...place, deployed_at: placeGenesisPlaza.deployed_at }).toEqual({
       ...placeGenesisPlaza,
       id: place.id,
       featured: true,
       contact_name: null,
       created_at: place.created_at,
       updated_at: place.updated_at,
-      deployed_at: place.deployed_at,
       featured_image: place.featured_image,
       highlighted_image: place.highlighted_image,
     })

--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -75,7 +75,8 @@
       "filter": "Filter",
       "sort_by": "Sort by",
       "pois": "Point of interest",
-      "featured": "Featured"
+      "featured": "Featured",
+      "show_more": "Show More"
     },
     "my_places": {
       "title": "My Places",

--- a/src/modules/segment.ts
+++ b/src/modules/segment.ts
@@ -19,6 +19,7 @@ export enum SegmentPlace {
   Place = "Place",
   Places = "Places",
   PlacesChangePagination = "Places Change Pagination",
+  PlacesShowMore = "Places Show More",
   PlacesChangePois = "Places Change Pois",
   PlacesChangeOrder = "Places Change Order",
 }

--- a/src/modules/segment.ts
+++ b/src/modules/segment.ts
@@ -21,5 +21,6 @@ export enum SegmentPlace {
   PlacesChangePagination = "Places Change Pagination",
   PlacesShowMore = "Places Show More",
   PlacesChangePois = "Places Change Pois",
+  PlacesChangeFeatured = "Places Change Featured",
   PlacesChangeOrder = "Places Change Order",
 }

--- a/src/pages/places.css
+++ b/src/pages/places.css
@@ -25,6 +25,10 @@
 .ui.grid.places-page > .row > .column.places-page__list > div {
   display: flex;
 }
+.ui.grid.places-page > .row > .column.places-page__list .places__pagination {
+  justify-content: space-around;
+  padding-top: 60px;
+}
 
 .places-page .ui.button.filter-container__button {
   width: 100%;


### PR DESCRIPTION
The current pagination has been changed to a "Show More" button that loads new cards after the previous listing. When changing any of the filters or sorting, the listing is deleted and starts from the beginning with the new filter.

<img width="2056" alt="Screenshot 2023-04-27 at 16 25 49" src="https://user-images.githubusercontent.com/6572776/234971389-3026486b-40b7-4907-afd0-4a2617f30086.png">
<img width="507" alt="Screenshot 2023-04-27 at 16 26 05" src="https://user-images.githubusercontent.com/6572776/234971426-61852fdb-8dbf-4708-8a8f-3ea4bf1f2d99.png">
