### PR TITLE
fix: old entity scene replacing new with different size or base position

### DIFF
--- a/src/__data__/entities.ts
+++ b/src/__data__/entities.ts
@@ -447,7 +447,8 @@ export const placeGenesisPlaza: PlaceAttributes = {
   world: false,
   world_name: null,
   title: "Genesis Plaza",
-  description: null,
+  description:
+    "Jump in to strike up a chat with other visitors, retake the commands tutorial with a cute floating robot, or dive into the swirling portal to get to Decentraland's visitor center.",
   owner: null,
   image: "https://decentraland.org/images/thumbnail/genesis-plaza.png",
   tags: ["plaza"],
@@ -3610,6 +3611,8 @@ export const entitySceneGenesisPlaza: ContentEntityScene & { id: string } = {
   metadata: {
     display: {
       title: "Genesis Plaza",
+      description:
+        "Jump in to strike up a chat with other visitors, retake the commands tutorial with a cute floating robot, or dive into the swirling portal to get to Decentraland's visitor center.",
       favicon: "favicon_asset",
       navmapThumbnail:
         "https://decentraland.org/images/thumbnail/genesis-plaza.png",
@@ -6880,6 +6883,8 @@ export const contentEntitySceneGenesisPlaza: ContentEntityScene = {
   metadata: {
     display: {
       title: "Genesis Plaza",
+      description:
+        "Jump in to strike up a chat with other visitors, retake the commands tutorial with a cute floating robot, or dive into the swirling portal to get to Decentraland's visitor center.",
       favicon: "favicon_asset",
       navmapThumbnail:
         "https://decentraland.org/images/thumbnail/genesis-plaza.png",
@@ -9906,6 +9911,36 @@ export const contentEntitySceneRoad: ContentEntityScene = {
     main: "game.js",
     tags: [],
   },
+}
+
+export const placeRoad: PlaceAttributes = {
+  id: "c6adac03-0c7a-406d-8285-9abf8b19751f",
+  likes: 0,
+  dislikes: 0,
+  favorites: 0,
+  like_rate: 0,
+  highlighted: false,
+  highlighted_image: null,
+  featured: false,
+  featured_image: null,
+  disabled: false,
+  updated_at: new Date("2023-03-28T18:37:39.918Z"),
+  categories: [],
+  world: false,
+  world_name: null,
+  title: "Road at -89,11 (open road OpenRoad_C)",
+  description: null,
+  owner: null,
+  image: "https://decentraland.org/images/thumbnail/road.png",
+  tags: ["road"],
+  base_position: "-89,11",
+  positions: ["-89,11"],
+  contact_name: "Decentraland Foundation",
+  contact_email: null,
+  content_rating: null,
+  created_at: new Date("2023-03-28T18:37:39.918Z"),
+  disabled_at: null,
+  deployed_at: new Date("2022-11-14T17:22:05.307Z"),
 }
 
 export const hotSceneGenesisPlaza: HotScene = {

--- a/src/entities/CheckScenes/task/processContentEntityScene.ts
+++ b/src/entities/CheckScenes/task/processContentEntityScene.ts
@@ -4,7 +4,7 @@ import { v4 as uuid } from "uuid"
 
 import { PlaceAttributes } from "../../Place/types"
 import { getThumbnailFromContentDeployment as getThumbnailFromContentEntityScene } from "../../Place/utils"
-import { findSamePlace } from "../utils"
+import { findNewDeployedPlace, findSamePlace } from "../utils"
 
 const PLACES_URL = env("PLACES_URL", "https://places.decentraland.org")
 
@@ -25,21 +25,21 @@ export function processContentEntityScene(
   places: PlaceAttributes[]
 ): ProcessEntitySceneResult | null {
   const samePlace = findSamePlace(contentEntityScene, places)
-
+  const newDeployedPlace = findNewDeployedPlace(contentEntityScene, places)
+  if (newDeployedPlace) {
+    return null
+  }
   if (!samePlace) {
     return {
       new: createPlaceFromContentEntityScene(contentEntityScene),
       disabled: places,
     }
-  } else if (
-    new Date(samePlace.deployed_at) < new Date(contentEntityScene.timestamp)
-  ) {
-    return {
-      update: createPlaceFromContentEntityScene(contentEntityScene, samePlace),
-      disabled: places.filter((place) => samePlace.id !== place.id),
-    }
   }
-  return null
+
+  return {
+    update: createPlaceFromContentEntityScene(contentEntityScene, samePlace),
+    disabled: places.filter((place) => samePlace.id !== place.id),
+  }
 }
 
 export function createPlaceFromContentEntityScene(

--- a/src/entities/CheckScenes/utils.test.ts
+++ b/src/entities/CheckScenes/utils.test.ts
@@ -1,13 +1,21 @@
 import {
   contentEntitySceneGenesisPlaza,
   contentEntitySceneRoad,
+  placeGenesisPlaza,
   placeGenesisPlazaWithAggregatedAttributes,
+  placeRoad,
   sqsMessageWorld,
   worldAboutParalax,
   worldContentEntitySceneParalax,
   worldPlaceParalax,
 } from "../../__data__/entities"
-import { findSamePlace, getWorldAbout, isRoad, isSameWorld } from "./utils"
+import {
+  findNewDeployedPlace,
+  findSamePlace,
+  getWorldAbout,
+  isRoad,
+  isSameWorld,
+} from "./utils"
 
 describe("isRoads", () => {
   test("should return true, this is a road", async () => {
@@ -44,6 +52,28 @@ describe("isNewPlace", () => {
 
   test("should return true, is new place", async () => {
     expect(findSamePlace(contentEntitySceneGenesisPlaza, [])).toBeNull()
+  })
+})
+
+describe("findNewDeployedPlace", () => {
+  test("should return null if there are no places", async () => {
+    expect(findNewDeployedPlace(contentEntitySceneGenesisPlaza, [])).toBeNull()
+  })
+  test("should return null when the content entity scene do not find a place with deployed_at newer", async () => {
+    expect(
+      findNewDeployedPlace(contentEntitySceneGenesisPlaza, [
+        placeRoad,
+        { ...placeGenesisPlaza, deployed_at: new Date("2021-01-01") },
+      ])
+    ).toBeNull()
+  })
+  test("should return a place when the content entity scene find a place with deployed_at newer", async () => {
+    const now = new Date()
+    expect(
+      findNewDeployedPlace(contentEntitySceneGenesisPlaza, [
+        { ...placeGenesisPlaza, deployed_at: now },
+      ])
+    ).toEqual({ ...placeGenesisPlaza, deployed_at: now })
   })
 })
 

--- a/src/entities/CheckScenes/utils.ts
+++ b/src/entities/CheckScenes/utils.ts
@@ -77,6 +77,22 @@ export function findSamePlace(
   return null
 }
 
+export function findNewDeployedPlace(
+  contentEntityScene: ContentEntityScene,
+  places: PlaceAttributes[]
+): PlaceAttributes | null {
+  if (places.length === 0) {
+    return null
+  }
+
+  const newDeployedPlace = places.find(
+    (place) =>
+      new Date(place.deployed_at) > new Date(contentEntityScene.timestamp)
+  )
+
+  return newDeployedPlace || null
+}
+
 export function isSameWorld(
   contentEntityScene: ContentEntityScene,
   place: PlaceAttributes

--- a/src/entities/Snapshot/utils.test.ts
+++ b/src/entities/Snapshot/utils.test.ts
@@ -1,6 +1,6 @@
 import { fetchScore } from "./utils"
 
-test.skip("fetchScore", async () => {
+test("fetchScore", async () => {
   expect(await fetchScore("")).toBe(0)
   expect(await fetchScore("0x0000000000000000000000000000000000000000")).toBe(0)
   expect(


### PR DESCRIPTION
Problem description: if an entity scene shares one of the positions and it was previously deployed, it replaced the new one, and this should not be the behavior applying [ADR-186](https://adr.decentraland.org/adr/ADR-186).
