### PR TITLE
fix: Remove duplicated dot in favorites empty message

### DIFF
--- a/src/intl/en.json
+++ b/src/intl/en.json
@@ -82,7 +82,7 @@
       "title": "My Places",
       "favorites": "My Favorites",
       "no_favorite_selected": "You haven’t saved any Places to your favorites. Find ",
-      "go_to_overview": "the places you like most."
+      "go_to_overview": "the places you like most"
     }
   },
   "social": {


### PR DESCRIPTION
<img width="787" alt="image" src="https://github.com/decentraland/places/assets/31735779/82c763c1-50ac-4737-83fc-b8af53a6f327">
