### PR TITLE
feat: change filtering behavior

### DIFF
--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -7,7 +7,6 @@ import useFeatureFlagContext from "decentraland-gatsby/dist/context/FeatureFlag/
 import useTrackLinkContext from "decentraland-gatsby/dist/context/Track/useTrackLinkContext"
 import useFormatMessage from "decentraland-gatsby/dist/hooks/useFormatMessage"
 import { navigate } from "decentraland-gatsby/dist/plugins/intl"
-import debounce from "decentraland-gatsby/dist/utils/function/debounce"
 
 import { PlaceListOrderBy } from "../../entities/Place/types"
 import { WorldListOrderBy } from "../../entities/World/types"
@@ -79,7 +78,7 @@ export default function Navigation(props: NavigationProps) {
           <NavigationMenu.Item
             active={props.activeTab === NavigationTab.Places}
             href={locations.places({
-              order_by: PlaceListOrderBy.HIGHEST_RATED,
+              order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
             })}
           >
             {l("navigation.places")}
@@ -88,7 +87,7 @@ export default function Navigation(props: NavigationProps) {
             <NavigationMenu.Item
               active={props.activeTab === NavigationTab.Worlds}
               href={locations.worlds({
-                order_by: WorldListOrderBy.HIGHEST_RATED,
+                order_by: WorldListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
               })}
             >
               {l("navigation.worlds")}

--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -78,7 +78,7 @@ export default function Navigation(props: NavigationProps) {
           <NavigationMenu.Item
             active={props.activeTab === NavigationTab.Places}
             href={locations.places({
-              order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
+              order_by: PlaceListOrderBy.MOST_ACTIVE,
             })}
           >
             {l("navigation.places")}

--- a/src/entities/Place/types.ts
+++ b/src/entities/Place/types.ts
@@ -49,8 +49,6 @@ export type GetPlaceParams = {
 
 export enum PlaceListOrderBy {
   MOST_ACTIVE = "most_active",
-  // deprecated
-  HIGHEST_RATED = "like_rate",
   HIGHEST_RATED_LOWER_BOUND_SCORE = "like_score",
   UPDATED_AT = "updated_at",
   USER_VISITS = "user_visits",

--- a/src/entities/Social/routes.ts
+++ b/src/entities/Social/routes.ts
@@ -48,7 +48,7 @@ export async function injectPlaceMetadata(req: Request, res: Response) {
         only_favorites: false,
         only_featured: false,
         only_highlighted: false,
-        order_by: PlaceListOrderBy.HIGHEST_RATED,
+        order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
         order: "asc",
         search: "",
       })

--- a/src/entities/World/types.ts
+++ b/src/entities/World/types.ts
@@ -9,8 +9,6 @@ export type GetWorldListQuery = {
 }
 
 export enum WorldListOrderBy {
-  // deprecated
-  HIGHEST_RATED = "like_rate",
   HIGHEST_RATED_LOWER_BOUND_SCORE = "like_score",
   MOST_ACTIVE = "most_active",
 }

--- a/src/modules/locations.ts
+++ b/src/modules/locations.ts
@@ -37,7 +37,7 @@ const pageOptionsDefault: PlacesPageOptions = {
   only_pois: false,
   only_featured: false,
   only_highlighted: false,
-  order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
+  order_by: PlaceListOrderBy.MOST_ACTIVE,
   order: "desc",
   page: 1,
   search: "",

--- a/src/modules/locations.ts
+++ b/src/modules/locations.ts
@@ -37,7 +37,7 @@ const pageOptionsDefault: PlacesPageOptions = {
   only_pois: false,
   only_featured: false,
   only_highlighted: false,
-  order_by: PlaceListOrderBy.HIGHEST_RATED,
+  order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
   order: "desc",
   page: 1,
   search: "",
@@ -45,7 +45,7 @@ const pageOptionsDefault: PlacesPageOptions = {
 
 const pageWorldsOptionsDefault: WorldsPageOptions = {
   only_favorites: false,
-  order_by: WorldListOrderBy.HIGHEST_RATED,
+  order_by: WorldListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
   order: "desc",
   page: 1,
   search: "",
@@ -81,7 +81,7 @@ export function toWorldsOptions(params: URLSearchParams): WorldsPageOptions {
       oneOf(
         params.get("order_by"),
         getWorldListQuerySchema.properties.order_by.enum
-      ) ?? WorldListOrderBy.HIGHEST_RATED,
+      ) ?? WorldListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
     order:
       oneOf(params.get("order"), ["asc", "desc"]) ?? pageOptionsDefault.order,
     page: numeric(params.get("page"), { min: 1 }) ?? pageOptionsDefault.page,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -175,7 +175,7 @@ export default function OverviewPage() {
         places={hightRatedList}
         title={l("pages.overview.highest_rated")}
         href={locations.places({
-          order_by: PlaceListOrderBy.HIGHEST_RATED,
+          order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
         })}
         onClickFavorite={(e, place) =>
           handleFavorite(place.id, place, {

--- a/src/pages/places.tsx
+++ b/src/pages/places.tsx
@@ -168,6 +168,11 @@ export default function IndexPage() {
         only_featured: false,
         only_pois: !!props.value,
       }
+
+      if (newParams.order_by && newParams.only_pois) {
+        newParams.order_by = PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE
+      }
+
       setAllPlaces([])
       track(SegmentPlace.FilterChange, {
         filters: newParams,
@@ -187,6 +192,11 @@ export default function IndexPage() {
         only_pois: false,
         only_featured: !!props.value,
       }
+
+      if (newParams.order_by && newParams.only_featured) {
+        newParams.order_by = PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE
+      }
+
       setAllPlaces([])
       track(SegmentPlace.FilterChange, {
         filters: newParams,

--- a/src/pages/places.tsx
+++ b/src/pages/places.tsx
@@ -201,7 +201,7 @@ export default function IndexPage() {
     (_: React.SyntheticEvent<any>, props: { value?: any }) => {
       const value =
         oneOf(props.value, getPlaceListQuerySchema.properties.order_by.enum) ??
-        PlaceListOrderBy.HIGHEST_RATED
+        PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE
       const newParams = { ...params, order_by: value, page: 1 }
       setAllPlaces([])
       track(SegmentPlace.FilterChange, {
@@ -217,7 +217,7 @@ export default function IndexPage() {
     track(SegmentPlace.FilterClear)
     navigate(
       locations.places({
-        order_by: PlaceListOrderBy.HIGHEST_RATED,
+        order_by: PlaceListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
       })
     )
   }, [params, track])

--- a/src/pages/worlds.tsx
+++ b/src/pages/worlds.tsx
@@ -150,7 +150,7 @@ export default function WorldsPage() {
     (_: React.SyntheticEvent<any>, props: { value?: any }) => {
       const value =
         oneOf(props.value, getWorldListQuerySchema.properties.order_by.enum) ??
-        WorldListOrderBy.HIGHEST_RATED
+        WorldListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE
       const newParams = { ...params, order_by: value, page: 1 }
       setAllWorlds([])
       track(SegmentPlace.FilterChange, {
@@ -166,7 +166,7 @@ export default function WorldsPage() {
     track(SegmentPlace.FilterClear)
     navigate(
       locations.worlds({
-        order_by: WorldListOrderBy.HIGHEST_RATED,
+        order_by: WorldListOrderBy.HIGHEST_RATED_LOWER_BOUND_SCORE,
       })
     )
   }, [params, track])


### PR DESCRIPTION
This PR:
changes the way how the filtering works. Now the default filter, when you hit /places, it's "Most Active". If you click on either "PoI" or "Featured", the filter is automatically changed to "Highest Rated". Then the user can select "Most Active" again but we do this in order to display a more complete list of the places. 