### PR TITLE
fix: Add Sentry CDN url to the CSP

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -97,6 +97,7 @@ app.use(
         "https://widget.intercom.io",
         "https://js.intercomcdn.com",
         "https://verify.walletconnect.com",
+        "https://js.sentry-cdn.com",
       ].join(" "),
     },
   })


### PR DESCRIPTION
Because of the following error, I added Sentry to the CSP:

```
VM38:1 Refused to load the script 'https://js.sentry-cdn.com/80e0eccb5419f5bfe97b9adf08ca0e1f.min.js' because it violates the following Content Security Policy directive
```