### PR TITLE
fix: update checkPoisForCategoryUpdate task

### DIFF
--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -420,7 +420,10 @@ export default class PlaceModel extends Model<PlaceAttributes> {
   }
 
   static overrideCategories(placeId: string, newCategories: string[]) {
-    const categories = join(newCategories.map((category) => SQL`${category}`))
+    const categories =
+      newCategories.length > 0
+        ? join(newCategories.map((category) => SQL`${category}`))
+        : SQL`ARRAY[]::text[]`
 
     const sql = SQL`UPDATE ${table(
       this

--- a/src/entities/PlaceCategories/tasks/poi.ts
+++ b/src/entities/PlaceCategories/tasks/poi.ts
@@ -28,28 +28,32 @@ const processNewPois = async (pois: string[], logger: Logger) => {
   logger.log(`> Processing new PoIs > poi Places ${poiPlaces.length}`)
 
   // Places to be removed from POI category
-  const toBeRemoved = diff(categorizedPlaces, poiPlaces)
+  const toBeRemoved = diff(
+    categorizedPlaces.map(({ id }) => id),
+    poiPlaces.map(({ id }) => id)
+  )
 
   // Places to be added to POI Category
-  const toBeAdded = diff(poiPlaces, categorizedPlaces).map((poiPlace) => [
-    poiPlace.id,
-    DecentralandCategories.POI,
-  ])
+  const toBeAdded = diff(
+    poiPlaces.map(({ id }) => id),
+    categorizedPlaces.map(({ id }) => id)
+  ).map((placeId) => [placeId, DecentralandCategories.POI])
 
   logger.log(`> Processing new PoIs > to be removed ${toBeRemoved.length}`)
 
   // TODO: review, reduce queries?
-  for (const removable of toBeRemoved) {
-    logger.log(`> Processing new PoIs > removing: ${removable.id}`)
+  for (const removableId of toBeRemoved) {
+    logger.log(`> Processing new PoIs > removing: ${removableId}`)
     await PlaceCategories.removeCategoryFromPlace(
-      removable.id,
+      removableId,
       DecentralandCategories.POI
     )
     const currentCategories = await PlaceCategories.findCategoriesByPlaceId(
-      removable.id
+      removableId
     )
+
     await PlaceModel.overrideCategories(
-      removable.id,
+      removableId,
       currentCategories.map(({ category_id }) => category_id)
     )
   }


### PR DESCRIPTION
The problem arises in the way the places are compared. 
We use a diff function from the RADASH library, but when comparing arrays of objects, the differentiation is complicated. 
It was changed to compare array of ids, which is the only important data we need.