### PR TITLE
feat: Add a new order_by option created_at

### DIFF
--- a/src/entities/Place/model.test.ts
+++ b/src/entities/Place/model.test.ts
@@ -174,7 +174,7 @@ describe(`findWithAggregates`, () => {
           AND p.base_position IN (
             SELECT DISTINCT(base_position) FROM "place_positions" WHERE position IN ($1)
           )
-        ORDER BY p.like_score DESC NULLS LAST, p."deployed_at" DESC
+        ORDER BY p.created_at DESC NULLS LAST, p."deployed_at" DESC
           LIMIT $2
           OFFSET $3
       `
@@ -218,7 +218,7 @@ describe(`findWithAggregates`, () => {
         WHERE p."disabled" is false AND "world" is false AND p.base_position IN (
           SELECT DISTINCT(base_position) FROM "place_positions" WHERE position IN ($3)
         )
-        ORDER BY p.like_score DESC NULLS LAST, p."deployed_at" DESC
+        ORDER BY p.created_at DESC NULLS LAST, p."deployed_at" DESC
           LIMIT $4
           OFFSET $5
       `
@@ -265,7 +265,7 @@ describe(`findWithAggregates`, () => {
           SELECT DISTINCT(base_position) FROM "place_positions" WHERE position IN ($4)
         )
         ORDER BY rank DESC,
-          p.like_score DESC NULLS LAST, p."deployed_at" DESC
+          p.created_at DESC NULLS LAST, p."deployed_at" DESC
           LIMIT $5
           OFFSET $6
       `
@@ -504,7 +504,7 @@ describe(`findWithHotScenes`, () => {
           AND p.base_position IN (
             SELECT DISTINCT(base_position) FROM "place_positions" WHERE position IN ($1)
           )
-        ORDER BY p.like_score DESC NULLS LAST, p."deployed_at" DESC
+        ORDER BY p.created_at DESC NULLS LAST, p."deployed_at" DESC
           LIMIT $2
           OFFSET $3
       `
@@ -606,7 +606,7 @@ describe(`findWorld`, () => {
             p.disabled is false
             AND world is true
             AND world_name IN ($1)
-          ORDER BY p.like_score DESC NULLS LAST, p."deployed_at" DESC
+          ORDER BY p.created_at DESC NULLS LAST, p."deployed_at" DESC
             LIMIT $2
             OFFSET $3
       `
@@ -652,7 +652,7 @@ describe(`findWorld`, () => {
           AND world is true
           AND world_name IN ($4)
           AND rank > 0
-        ORDER BY rank DESC, p.like_score DESC NULLS LAST, p."deployed_at" DESC
+        ORDER BY rank DESC, p.created_at DESC NULLS LAST, p."deployed_at" DESC
           LIMIT $5
           OFFSET $6
       `

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -142,7 +142,7 @@ export default class PlaceModel extends Model<PlaceAttributes> {
       return []
     }
 
-    const orderBy = PlaceListOrderBy.LIKE_SCORE_BEST
+    const orderBy = options.order_by ?? PlaceListOrderBy.LIKE_SCORE_BEST
     const orderDirection = oneOf(options.order, ["asc", "desc"]) ?? "desc"
 
     const order = SQL.raw(
@@ -451,7 +451,7 @@ export default class PlaceModel extends Model<PlaceAttributes> {
       return []
     }
 
-    const orderBy = WorldListOrderBy.LIKE_SCORE_BEST
+    const orderBy = options.order_by ?? WorldListOrderBy.LIKE_SCORE_BEST
     const orderDirection = oneOf(options.order, ["asc", "desc"]) ?? "desc"
 
     const order = SQL.raw(

--- a/src/entities/Place/routes/getPlaceList.ts
+++ b/src/entities/Place/routes/getPlaceList.ts
@@ -46,6 +46,7 @@ export const getPlaceList = Router.memo(
         oneOf(ctx.url.searchParams.get("order_by"), [
           PlaceListOrderBy.LIKE_SCORE_BEST,
           PlaceListOrderBy.UPDATED_AT,
+          PlaceListOrderBy.CREATED_AT,
         ]) || PlaceListOrderBy.LIKE_SCORE_BEST,
       order:
         oneOf(ctx.url.searchParams.get("order"), ["asc", "desc"]) || "desc",

--- a/src/entities/Place/schemas.ts
+++ b/src/entities/Place/schemas.ts
@@ -46,7 +46,11 @@ export const getPlaceListQuerySchema = schema({
     order_by: {
       type: "string",
       description: "Order places by",
-      enum: [PlaceListOrderBy.LIKE_SCORE_BEST, PlaceListOrderBy.MOST_ACTIVE],
+      enum: [
+        PlaceListOrderBy.LIKE_SCORE_BEST,
+        PlaceListOrderBy.MOST_ACTIVE,
+        PlaceListOrderBy.CREATED_AT,
+      ],
       nullable: true as any,
     },
     order: {

--- a/src/entities/Place/types.ts
+++ b/src/entities/Place/types.ts
@@ -63,6 +63,7 @@ export enum PlaceListOrderBy {
   LIKE_SCORE_BEST = "like_score",
   UPDATED_AT = "updated_at",
   USER_VISITS = "user_visits",
+  CREATED_AT = "created_at",
 }
 
 export type GetPlaceListQuery = {

--- a/src/entities/World/routes/getWorldList.ts
+++ b/src/entities/World/routes/getWorldList.ts
@@ -29,7 +29,12 @@ export const getWorldList = Router.memo(
       offset: ctx.url.searchParams.get("offset"),
       limit: ctx.url.searchParams.get("limit"),
       only_favorites: ctx.url.searchParams.get("only_favorites"),
-      order_by: WorldListOrderBy.MOST_ACTIVE,
+      order_by:
+        oneOf(ctx.url.searchParams.get("order_by"), [
+          WorldListOrderBy.MOST_ACTIVE,
+          WorldListOrderBy.LIKE_SCORE_BEST,
+          WorldListOrderBy.CREATED_AT,
+        ]) || WorldListOrderBy.MOST_ACTIVE,
       search: ctx.url.searchParams.get("search"),
       order:
         oneOf(ctx.url.searchParams.get("order"), ["asc", "desc"]) || "desc",

--- a/src/entities/World/schemas.ts
+++ b/src/entities/World/schemas.ts
@@ -32,7 +32,11 @@ export const getWorldListQuerySchema = schema({
     order_by: {
       type: "string",
       description: "Order worlds by",
-      enum: [WorldListOrderBy.LIKE_SCORE_BEST, WorldListOrderBy.MOST_ACTIVE],
+      enum: [
+        WorldListOrderBy.LIKE_SCORE_BEST,
+        WorldListOrderBy.MOST_ACTIVE,
+        WorldListOrderBy.CREATED_AT,
+      ],
       nullable: true as any,
     },
     order: {

--- a/src/entities/World/types.ts
+++ b/src/entities/World/types.ts
@@ -12,6 +12,7 @@ export type GetWorldListQuery = {
 export enum WorldListOrderBy {
   LIKE_SCORE_BEST = "like_score",
   MOST_ACTIVE = "most_active",
+  CREATED_AT = "created_at",
 }
 
 export type WorldListOptions = {


### PR DESCRIPTION
This PR adds a new option: `created_at` to sort places