### PR TITLE
fix: Get most active places

### DIFF
--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -227,6 +227,19 @@ export default class PlaceModel extends Model<PlaceAttributes> {
             )`
         )}
       ORDER BY 
+      ${conditional(
+        options.order_by === PlaceListOrderBy.MOST_ACTIVE &&
+          !!options.hotScenesPositions &&
+          options.hotScenesPositions.length > 0,
+        SQL`CASE 
+              WHEN p.base_position IN (
+                SELECT DISTINCT(base_position)
+                FROM ${table(PlacePositionModel)}
+                WHERE position IN ${values(options.hotScenesPositions!)}
+              ) THEN 0
+              ELSE 1
+            END,`
+      )}
       ${conditional(!!options.search, SQL`rank DESC, `)}
       ${order}
       ${limit(options.limit, { max: 100 })}

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -235,7 +235,7 @@ export default class PlaceModel extends Model<PlaceAttributes> {
               WHEN p.base_position IN (
                 SELECT DISTINCT(base_position)
                 FROM ${table(PlacePositionModel)}
-                WHERE position IN ${values(options.hotScenesPositions!)}
+                WHERE position IN ${values(options.hotScenesPositions ?? [])}
               ) THEN 0
               ELSE 1
             END,`

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -160,7 +160,20 @@ export default class PlaceModel extends Model<PlaceAttributes> {
       `p.${orderBy} ${orderDirection.toUpperCase()} NULLS LAST, p."deployed_at" DESC`
     )
 
+    const filterMostActivePlaces =
+      options.order_by === PlaceListOrderBy.MOST_ACTIVE &&
+      !!options.hotScenesPositions &&
+      options.hotScenesPositions.length > 0
+
     const sql = SQL`
+      ${conditional(
+        filterMostActivePlaces,
+        SQL`WITH most_active_places AS (
+              SELECT DISTINCT base_position
+              FROM "place_positions"
+              WHERE position IN ${values(options.hotScenesPositions || [])}
+            )`
+      )}
       SELECT p.*
       ${conditional(
         !!options.user,
@@ -177,6 +190,10 @@ export default class PlaceModel extends Model<PlaceAttributes> {
         SQL`, not coalesce(ul."like",true) as "user_dislike"`
       )}
       ${conditional(!options.user, SQL`, false as "user_dislike"`)}
+      ${conditional(
+        filterMostActivePlaces,
+        SQL`, (map.base_position IS NOT NULL)::int AS is_most_active_place`
+      )}
       FROM ${table(this)} p
 
       ${conditional(
@@ -207,6 +224,11 @@ export default class PlaceModel extends Model<PlaceAttributes> {
       )}
 
       ${conditional(
+        filterMostActivePlaces,
+        SQL`LEFT JOIN most_active_places "map" ON p.base_position = map.base_position`
+      )}
+
+      ${conditional(
         !!options.search,
         SQL`, ts_rank_cd(p.textsearch, to_tsquery(${tsquery(
           options.search || ""
@@ -227,19 +249,7 @@ export default class PlaceModel extends Model<PlaceAttributes> {
             )`
         )}
       ORDER BY 
-      ${conditional(
-        options.order_by === PlaceListOrderBy.MOST_ACTIVE &&
-          !!options.hotScenesPositions &&
-          options.hotScenesPositions.length > 0,
-        SQL`CASE 
-              WHEN p.base_position IN (
-                SELECT DISTINCT(base_position)
-                FROM ${table(PlacePositionModel)}
-                WHERE position IN ${values(options.hotScenesPositions ?? [])}
-              ) THEN 0
-              ELSE 1
-            END,`
-      )}
+      ${conditional(filterMostActivePlaces, SQL`is_most_active_place DESC, `)}
       ${conditional(!!options.search, SQL`rank DESC, `)}
       ${order}
       ${limit(options.limit, { max: 100 })}

--- a/src/entities/Place/routes/getPlaceMostActiveList.ts
+++ b/src/entities/Place/routes/getPlaceMostActiveList.ts
@@ -52,17 +52,14 @@ export const getPlaceMostActiveList = Router.memo(
       return new ApiResponse([], { total: 0 })
     }
 
-    const positions = new Set(query.positions)
-
     const options: FindWithAggregatesOptions = {
       user: userAuth?.address,
       offset: numeric(query.offset, { min: 0 }) ?? 0,
       limit: numeric(query.limit, { min: 0, max: 100 }) ?? 100,
       only_favorites: !!bool(query.only_favorites),
       only_highlighted: !!bool(query.only_highlighted),
-      positions: query.positions.length
-        ? hotScenesPositions.filter((position) => positions.has(position))
-        : hotScenesPositions,
+      positions: query.positions,
+      hotScenesPositions: hotScenesPositions,
       order_by: PlaceListOrderBy.MOST_ACTIVE,
       order: query.order,
       search: query.search,

--- a/src/entities/Place/types.ts
+++ b/src/entities/Place/types.ts
@@ -93,6 +93,7 @@ export type PlaceListOptions = {
 
 export type FindWithAggregatesOptions = PlaceListOptions & {
   user?: string
+  hotScenesPositions?: string[]
 }
 
 export const unwantedThumbnailHash = [


### PR DESCRIPTION
This PR fixes an issue where the most active places endpoint could return an empty list when no scenes were available from `https://realm-provider.decentraland.org/hot-scenes`. With this update, the endpoint now filters and orders places according to the available scenes returned by the hot-scenes provider, ensuring that it does not return an empty list.