### PR TITLE
fix: Update decentraland-gatsby to use new tasks manager

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "caniuse-lite": "^1.0.30001470",
         "core-js": "^3.22.2",
         "cssnano": "^5.0.10",
-        "decentraland-gatsby": "^6.54.0",
+        "decentraland-gatsby": "^7.0.0",
         "decentraland-ui": "^6.14.0",
         "es6-shim": "^0.35.8",
         "express-fileupload": "^1.2.1",
@@ -21885,9 +21885,9 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "6.54.0",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-6.54.0.tgz",
-      "integrity": "sha512-dt8q1/xRHJ6Re6hyWPSyl0gTctYTTm7ggnkmv7H3kX14jiZDy6FDGASx4BEIBwM2agD7nAeMtJy1tEMRokLV0g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-7.0.0.tgz",
+      "integrity": "sha512-q/2NEjrIZbkTzAQUxBYSwzXw1cCSsFwN3KFdTGH/AAY2gG/+UgXKGRRNDxejN9RpPGg8Gze+X0fOwQlMTrbalQ==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",
@@ -60657,9 +60657,9 @@
       }
     },
     "decentraland-gatsby": {
-      "version": "6.54.0",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-6.54.0.tgz",
-      "integrity": "sha512-dt8q1/xRHJ6Re6hyWPSyl0gTctYTTm7ggnkmv7H3kX14jiZDy6FDGASx4BEIBwM2agD7nAeMtJy1tEMRokLV0g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-7.0.0.tgz",
+      "integrity": "sha512-q/2NEjrIZbkTzAQUxBYSwzXw1cCSsFwN3KFdTGH/AAY2gG/+UgXKGRRNDxejN9RpPGg8Gze+X0fOwQlMTrbalQ==",
       "requires": {
         "@aws-sdk/client-ses": "^3.421.0",
         "@dcl/crypto": "^3.4.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "caniuse-lite": "^1.0.30001470",
     "core-js": "^3.22.2",
     "cssnano": "^5.0.10",
-    "decentraland-gatsby": "^6.54.0",
+    "decentraland-gatsby": "^7.0.0",
     "decentraland-ui": "^6.14.0",
     "es6-shim": "^0.35.8",
     "express-fileupload": "^1.2.1",


### PR DESCRIPTION
This PR updates the `decentraland-gatsby` dependency to use the new Tasks Manager.