### PR TITLE
docs: Add AI Agent Context section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,38 +78,4 @@ docker-compose up -d     # Start services
 
 ## AI Agent Context
 
-**Service Purpose:** Processes Catalyst scene and World deployments to maintain a searchable database of Decentraland places. Fetches entity metadata from Catalyst content servers and creates Place records for discovery, search, and navigation features.
-
-**Key Capabilities:**
-
-- Receives deployment notifications via AWS SQS for scenes and worlds
-- Fetches entity metadata from Catalyst content servers using entity IDs
-- Creates and maintains Place records in PostgreSQL database
-- Provides API for querying places (scene coordinates, world names, metadata)
-- Supports Gatsby frontend integration for place discovery interface
-
-**Communication Pattern:**
-
-- Event-driven via AWS SQS (deployment notifications)
-- Synchronous HTTP API (place queries)
-
-**Technology Stack:**
-
-- Runtime: Node.js
-- Language: TypeScript
-- HTTP Framework: Express
-- Database: PostgreSQL (via node-pg-migrate)
-- Queue: AWS SQS (deployment event consumption)
-- Component Architecture: @well-known-components (logger, http-server)
-
-**External Dependencies:**
-
-- Content Servers: Catalyst nodes (fetches scene/world entity metadata)
-- Queue: AWS SQS (receives deployment events)
-- Database: PostgreSQL (place records, scene/world metadata)
-
-**Project Structure:**
-
-- `src/adapters/`: Database adapters, SQS clients
-- `src/logic/`: Place processing logic, entity fetching
-- `bin/`: Utility scripts
+For detailed AI Agent context, see [docs/ai-agent-context.md](docs/ai-agent-context.md).

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -1,0 +1,37 @@
+# AI Agent Context
+
+**Service Purpose:** Processes Catalyst scene and World deployments to maintain a searchable database of Decentraland places. Fetches entity metadata from Catalyst content servers and creates Place records for discovery, search, and navigation features.
+
+**Key Capabilities:**
+
+- Receives deployment notifications via AWS SQS for scenes and worlds
+- Fetches entity metadata from Catalyst content servers using entity IDs
+- Creates and maintains Place records in PostgreSQL database
+- Provides API for querying places (scene coordinates, world names, metadata)
+- Supports Gatsby frontend integration for place discovery interface
+
+**Communication Pattern:**
+
+- Event-driven via AWS SQS (deployment notifications)
+- Synchronous HTTP API (place queries)
+
+**Technology Stack:**
+
+- Runtime: Node.js
+- Language: TypeScript
+- HTTP Framework: Express
+- Database: PostgreSQL (via node-pg-migrate)
+- Queue: AWS SQS (deployment event consumption)
+- Component Architecture: @well-known-components (logger, http-server)
+
+**External Dependencies:**
+
+- Content Servers: Catalyst nodes (fetches scene/world entity metadata)
+- Queue: AWS SQS (receives deployment events)
+- Database: PostgreSQL (place records, scene/world metadata)
+
+**Project Structure:**
+
+- `src/adapters/`: Database adapters, SQS clients
+- `src/logic/`: Place processing logic, entity fetching
+- `bin/`: Utility scripts


### PR DESCRIPTION
This PR adds a comprehensive AI Agent Context section to the README to help AI agents better understand the project structure, capabilities, and dependencies for cross-project editing.

## Changes
- Added 🤖 AI Agent Context section with:
  - Service purpose and key capabilities
  - Communication patterns
  - Technology stack details
  - External dependencies
  - API specifications
  - Project structure details

This improves AI agent understanding of the project for better code assistance and cross-project awareness.