### PR TITLE
feat: implement batch checking for live events in Events API

### DIFF
--- a/src/config/local.json
+++ b/src/config/local.json
@@ -1,6 +1,6 @@
 {
   "GATSBY_CHAIN_ID": "1,137",
-  "GATSBY_EVENTS_API_URL": "/api",
+  "GATSBY_EVENTS_API_URL": "https://events.decentraland.zone/api",
   "GATSBY_DECENTRALAND_URL": "https://play.decentraland.org",
   "GATSBY_LAND_URL": "https://api.decentraland.org",
   "GATSBY_PLACES_URL": "/api",

--- a/src/entities/Destination/routes/getDestinationsList.test.ts
+++ b/src/entities/Destination/routes/getDestinationsList.test.ts
@@ -271,7 +271,6 @@ describe("getDestinationsList", () => {
 
       beforeEach(() => {
         mockEventsInstance = {
-          hasLiveEvent: jest.fn().mockResolvedValue(true),
           checkLiveEventsForDestinations: jest
             .fn()
             .mockImplementation(async (destinationIds: string[]) => {
@@ -313,7 +312,6 @@ describe("getDestinationsList", () => {
 
       beforeEach(() => {
         mockEventsInstance = {
-          hasLiveEvent: jest.fn().mockResolvedValue(false),
           checkLiveEventsForDestinations: jest
             .fn()
             .mockImplementation(async (destinationIds: string[]) => {


### PR DESCRIPTION
- Added a new method `checkLiveEventsForDestinations` to allow batch checking of live events for multiple destinations.
- Updated the API to use a POST request with a JSON body for improved performance and clarity.
- Enhanced caching mechanism to store live event status per destination with a 5-minute TTL.
- Modified tests to cover new functionality and ensure accurate live event status retrieval for multiple destinations.