### PR TITLE
fix: update Events API endpoint for live events query

### DIFF
--- a/src/api/Events.test.ts
+++ b/src/api/Events.test.ts
@@ -46,9 +46,9 @@ describe("Events API", () => {
         expect(result.get("place-2")).toBe(false)
       })
 
-      it("should call the events API with list=live query param", () => {
+      it("should call the events API search endpoint with list=live query param", () => {
         expect(fetchMock).toHaveBeenCalledWith(
-          "/events?list=live",
+          "/events/search?list=live",
           expect.anything()
         )
       })

--- a/src/api/Events.ts
+++ b/src/api/Events.ts
@@ -113,7 +113,7 @@ export default class Events extends API {
 
     try {
       const response = await this.fetch<EventsResponse>(
-        `/events?list=live`,
+        `/events/search?list=live`,
         fetchOptions
       )
 


### PR DESCRIPTION
- Changed the API endpoint from `/events?list=live` to `/events/search?list=live` for clarity and consistency.
- Updated corresponding test case to reflect the new endpoint.