### PR TITLE
fix: Make world names case-insensitive in Places database

### DIFF
--- a/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
+++ b/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
@@ -25,7 +25,7 @@ import WorldModel from "../../World/model"
 export async function handleWorldSettingsChanged(
   event: WorldSettingsChangedEvent
 ): Promise<void> {
-  const { worldName } = event.metadata
+  const worldName = event.metadata.worldName?.toLowerCase()
 
   if (!worldName) {
     logger.error("WorldSettingsChangedEvent missing world name (key)")

--- a/src/entities/CheckScenes/task/processContentEntityScene.ts
+++ b/src/entities/CheckScenes/task/processContentEntityScene.ts
@@ -112,9 +112,11 @@ export function createPlaceFromContentEntityScene(
   }
 
   const worldName =
-    contentEntityScene?.metadata?.worldConfiguration?.name ||
-    contentEntityScene?.metadata?.worldConfiguration?.dclName ||
-    null
+    (
+      contentEntityScene?.metadata?.worldConfiguration?.name ||
+      contentEntityScene?.metadata?.worldConfiguration?.dclName ||
+      null
+    )?.toLowerCase() ?? null
 
   const contentEntitySceneRating =
     contentEntityScene?.metadata?.policy?.contentRating ||

--- a/src/entities/CheckScenes/task/taskRunnerSqs.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.ts
@@ -82,7 +82,7 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
 
   if (contentEntityScene.metadata.worldConfiguration) {
     const worldName = (contentEntityScene.metadata.worldConfiguration.name ||
-      contentEntityScene.metadata.worldConfiguration.dclName) as string
+      contentEntityScene.metadata.worldConfiguration.dclName)!.toLowerCase()
 
     // Determine if opt-out is set
     const isOptOut =

--- a/src/entities/CheckScenes/utils.test.ts
+++ b/src/entities/CheckScenes/utils.test.ts
@@ -295,6 +295,19 @@ describe("isSameWorld", () => {
     ).toBeTruthy()
   })
 
+  test("should return true when world names differ only in casing", async () => {
+    const upperCaseScene = {
+      ...worldContentEntitySceneParalax,
+      metadata: {
+        ...worldContentEntitySceneParalax.metadata,
+        worldConfiguration: {
+          name: "Paralax.DCL.eth",
+        },
+      },
+    }
+    expect(isSameWorld(upperCaseScene, worldPlaceParalax)).toBeTruthy()
+  })
+
   test("should return false, is not same world", async () => {
     expect(findSamePlace(contentEntitySceneGenesisPlaza, [])).toBeNull()
   })

--- a/src/entities/CheckScenes/utils.ts
+++ b/src/entities/CheckScenes/utils.ts
@@ -228,6 +228,7 @@ export function isSameWorld(
 ) {
   return (
     place.world &&
-    place.world_name === contentEntityScene.metadata.worldConfiguration?.name
+    place.world_name?.toLowerCase() ===
+      contentEntityScene.metadata.worldConfiguration?.name?.toLowerCase()
   )
 }

--- a/src/entities/Place/model.test.ts
+++ b/src/entities/Place/model.test.ts
@@ -79,7 +79,7 @@ describe(`findEnabledWorldName`, () => {
       `
         SELECT * FROM "places"
         WHERE "disabled" is false AND "world" is true
-          AND "world_name" = $1
+          AND LOWER("world_name") = $1
       `
         .trim()
         .replace(/\s{2,}/gi, " ")

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -268,7 +268,7 @@ export default class PlaceModel extends Model<PlaceAttributes> {
       WHERE
         "disabled" is false
         AND "world" is true
-        AND "world_name" = ${world_name}
+        AND LOWER("world_name") = ${world_name.toLowerCase()}
     `
 
     return this.namedQuery("find_enabled_by_world_name", sql)
@@ -851,7 +851,9 @@ export default class PlaceModel extends Model<PlaceAttributes> {
           WHERE position IN ${values(options.positions)}
         )
         OR
-        p.world_name IN ${values(options.names)}
+        LOWER(p.world_name) IN ${values(
+          options.names.map((n) => n.toLowerCase())
+        )}
       )`
     } else if (options.positions.length > 0) {
       placesOrWorldsCondition = SQL`AND p.base_position IN (
@@ -860,8 +862,8 @@ export default class PlaceModel extends Model<PlaceAttributes> {
         WHERE position IN ${values(options.positions)}
       )`
     } else if (options.names.length > 0) {
-      placesOrWorldsCondition = SQL`AND p.world_name IN ${values(
-        options.names
+      placesOrWorldsCondition = SQL`AND LOWER(p.world_name) IN ${values(
+        options.names.map((n) => n.toLowerCase())
       )}`
     } else {
       placesOrWorldsCondition = SQL`AND p.world is false`
@@ -970,7 +972,9 @@ export default class PlaceModel extends Model<PlaceAttributes> {
           WHERE position IN ${values(options.positions)}
         )
         OR
-        p.world_name IN ${values(options.names)}
+        LOWER(p.world_name) IN ${values(
+          options.names.map((n) => n.toLowerCase())
+        )}
       )`
     } else if (options.positions.length > 0) {
       placesOrWorldsCondition = SQL`AND p.base_position IN (
@@ -979,8 +983,8 @@ export default class PlaceModel extends Model<PlaceAttributes> {
         WHERE position IN ${values(options.positions)}
       )`
     } else if (options.names.length > 0) {
-      placesOrWorldsCondition = SQL`AND p.world_name IN ${values(
-        options.names
+      placesOrWorldsCondition = SQL`AND LOWER(p.world_name) IN ${values(
+        options.names.map((n) => n.toLowerCase())
       )}`
     } else {
       placesOrWorldsCondition = SQL`AND p.world is false`

--- a/src/entities/World/model.ts
+++ b/src/entities/World/model.ts
@@ -417,7 +417,7 @@ export default class WorldModel extends Model<WorldAttributes> {
 
     return {
       id: worldId,
-      world_name: world.world_name,
+      world_name: worldId,
       title: world.title ?? null,
       description: world.description ?? null,
       image: world.image ?? null,

--- a/src/migrations/1776342487771_normalize-world-names-case.ts
+++ b/src/migrations/1776342487771_normalize-world-names-case.ts
@@ -1,0 +1,59 @@
+import { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate"
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+/**
+ * Normalize world names to lowercase across both the worlds and places tables,
+ * and replace the case-sensitive UNIQUE constraint on worlds.world_name with
+ * a case-insensitive unique index.
+ *
+ * This prevents duplicate world records caused by casing differences
+ * (e.g., "lazaro.dcl.eth" vs "Lazaro.dcl.eth").
+ *
+ * See: https://github.com/decentraland/core-team/issues/145
+ */
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // 1. Normalize existing world_name values to lowercase in worlds table
+  pgm.sql(
+    `UPDATE worlds SET world_name = LOWER(world_name) WHERE world_name != LOWER(world_name)`
+  )
+
+  // 2. Normalize existing world_name values to lowercase in places table
+  pgm.sql(
+    `UPDATE places SET world_name = LOWER(world_name) WHERE world_name IS NOT NULL AND world_name != LOWER(world_name)`
+  )
+
+  // 3. Drop the existing case-sensitive unique constraint on worlds.world_name
+  //    (created by the "unique: true" option in the create-worlds-table migration)
+  pgm.sql(`ALTER TABLE worlds DROP CONSTRAINT IF EXISTS worlds_world_name_key`)
+
+  // 4. Drop the existing case-sensitive index
+  pgm.dropIndex("worlds", "world_name", {
+    name: "worlds_world_name_idx",
+    ifExists: true,
+  })
+
+  // 5. Create a case-insensitive unique index on worlds.world_name
+  pgm.sql(
+    `CREATE UNIQUE INDEX worlds_world_name_lower_unique_idx ON worlds (LOWER(world_name))`
+  )
+
+  // 6. Create a regular index for case-insensitive lookups
+  pgm.sql(`CREATE INDEX worlds_world_name_idx ON worlds (LOWER(world_name))`)
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Drop the case-insensitive indexes
+  pgm.sql(`DROP INDEX IF EXISTS worlds_world_name_lower_unique_idx`)
+  pgm.sql(`DROP INDEX IF EXISTS worlds_world_name_idx`)
+
+  // Restore the original case-sensitive unique constraint
+  pgm.sql(
+    `ALTER TABLE worlds ADD CONSTRAINT worlds_world_name_key UNIQUE (world_name)`
+  )
+
+  // Restore the original case-sensitive index
+  pgm.createIndex("worlds", "world_name", {
+    name: "worlds_world_name_idx",
+  })
+}


### PR DESCRIPTION
## Summary
- Normalizes world names to lowercase at all entry points (content server events, scene processing)
- Adds defensive lowercasing in the World model layer to prevent future regressions
- Fixes case-sensitive SQL queries in the Place model (`findEnabledWorldName`, destination queries)
- Makes `isSameWorld()` comparison case-insensitive
- Adds a database migration to normalize existing data and replace the case-sensitive UNIQUE constraint with a case-insensitive unique index

## Test plan
- [x] All 34 test suites pass (239 tests)
- [x] New test added verifying `isSameWorld` works with mixed casing
- [x] Updated `findEnabledWorldName` test to match new `LOWER()` query
- [ ] Verify migration runs cleanly on staging database
- [ ] Verify `GET /api/worlds?names=lazaro.dcl.eth` returns exactly 1 result

Closes https://github.com/decentraland/core-team/issues/145