### PR TITLE
feat: add admin PUT/DELETE /places/:place_id/featured endpoints

### DIFF
--- a/src/entities/Place/migration.test.ts
+++ b/src/entities/Place/migration.test.ts
@@ -169,7 +169,6 @@ describe("createPlaceFromDefaultPlaces", () => {
   test("should return a place", async () => {
     const data = await createPlaceFromDefaultPlaces([{ base_position: "0,0" }])
 
-    console.log(data)
     expect(data).toEqual([
       {
         ...placeGenesisPlaza,
@@ -179,6 +178,7 @@ describe("createPlaceFromDefaultPlaces", () => {
         deployed_at: data[0].deployed_at,
         image: data[0].image,
         id: data[0].id,
+        positions: data[0].positions,
       },
     ])
   })

--- a/src/entities/Place/routes/featured.test.ts
+++ b/src/entities/Place/routes/featured.test.ts
@@ -3,9 +3,8 @@ import { randomUUID } from "crypto"
 import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
 
 import { placeGenesisPlazaWithAggregatedAttributes } from "../../../__data__/placeGenesisPlazaWithAggregatedAttributes"
-import PlaceCategories from "../../PlaceCategories/model"
 import PlaceModel from "../model"
-import { addFeatured, removeFeatured } from "./featured"
+import { featured } from "./featured"
 
 const VALID_TOKEN = "test-service-token-12345"
 const place_id = randomUUID()
@@ -22,15 +21,10 @@ jest.mock("decentraland-gatsby/dist/utils/env", () => {
 })
 
 const findByIdWithAggregates = jest.spyOn(PlaceModel, "findByIdWithAggregates")
-const overrideCategories = jest.spyOn(PlaceModel, "overrideCategories")
-const addCategoryToPlace = jest.spyOn(PlaceCategories, "addCategoryToPlace")
-const removeCategoryFromPlace = jest.spyOn(
-  PlaceCategories,
-  "removeCategoryFromPlace"
-)
+const updatePlace = jest.spyOn(PlaceModel, "updatePlace")
 
-const buildAuthenticatedRequest = () => {
-  const request = new Request("/")
+const buildAuthenticatedRequest = (method: "PUT" | "DELETE") => {
+  const request = new Request("/", { method })
   request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
   return request
 }
@@ -43,22 +37,17 @@ beforeEach(() => {
 
 afterEach(() => {
   findByIdWithAggregates.mockReset()
-  overrideCategories.mockReset()
-  addCategoryToPlace.mockReset()
-  removeCategoryFromPlace.mockReset()
+  updatePlace.mockReset()
 })
 
 describe("featured", () => {
   describe("authentication", () => {
-    test.each([
-      ["addFeatured", addFeatured],
-      ["removeFeatured", removeFeatured],
-    ])(
+    test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 401 when authorization header is missing",
-      async (_, handler) => {
+      async (method) => {
         await expect(() =>
-          handler({
-            request: new Request("/"),
+          featured({
+            request: new Request("/", { method }),
             params: { place_id },
             url: buildUrl(),
           } as any)
@@ -66,17 +55,14 @@ describe("featured", () => {
       }
     )
 
-    test.each([
-      ["addFeatured", addFeatured],
-      ["removeFeatured", removeFeatured],
-    ])(
+    test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 403 when authorization token is invalid",
-      async (_, handler) => {
-        const request = new Request("/")
+      async (method) => {
+        const request = new Request("/", { method })
         request.headers.set("Authorization", "Bearer invalid-token")
 
         await expect(() =>
-          handler({
+          featured({
             request,
             params: { place_id },
             url: buildUrl(),
@@ -85,17 +71,14 @@ describe("featured", () => {
       }
     )
 
-    test.each([
-      ["addFeatured", addFeatured],
-      ["removeFeatured", removeFeatured],
-    ])(
+    test.each([["PUT"], ["DELETE"]] as const)(
       "%s rejects request when PLACES_ADMIN_AUTH_TOKEN is not configured",
-      async (_, handler) => {
+      async (method) => {
         mockEnvToken = ""
 
         await expect(() =>
-          handler({
-            request: buildAuthenticatedRequest(),
+          featured({
+            request: buildAuthenticatedRequest(method),
             params: { place_id },
             url: buildUrl(),
           } as any)
@@ -105,15 +88,12 @@ describe("featured", () => {
   })
 
   describe("validation", () => {
-    test.each([
-      ["addFeatured", addFeatured],
-      ["removeFeatured", removeFeatured],
-    ])(
+    test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 400 when place_id is not a valid UUID",
-      async (_, handler) => {
+      async (method) => {
         await expect(() =>
-          handler({
-            request: buildAuthenticatedRequest(),
+          featured({
+            request: buildAuthenticatedRequest(method),
             params: { place_id: "invalid-uuid" },
             url: buildUrl(),
           } as any)
@@ -123,107 +103,63 @@ describe("featured", () => {
   })
 
   describe("place lookup", () => {
-    test.each([
-      ["addFeatured", addFeatured],
-      ["removeFeatured", removeFeatured],
-    ])("%s returns 404 when place does not exist", async (_, handler) => {
-      findByIdWithAggregates.mockResolvedValueOnce(null as any)
+    test.each([["PUT"], ["DELETE"]] as const)(
+      "%s returns 404 when place does not exist",
+      async (method) => {
+        findByIdWithAggregates.mockResolvedValueOnce(null as any)
 
-      await expect(() =>
-        handler({
-          request: buildAuthenticatedRequest(),
-          params: { place_id },
-          url: buildUrl(),
-        } as any)
-      ).rejects.toThrow(`Not found place "${place_id}"`)
+        await expect(() =>
+          featured({
+            request: buildAuthenticatedRequest(method),
+            params: { place_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow(`Not found place "${place_id}"`)
+      }
+    )
+  })
+
+  describe("PUT", () => {
+    test("sets highlighted to true and returns updated place", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        highlighted: false,
+      })
+      updatePlace.mockResolvedValueOnce([] as any)
+
+      const response = await featured({
+        request: buildAuthenticatedRequest("PUT"),
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(updatePlace).toHaveBeenCalledWith(
+        expect.objectContaining({ highlighted: true }),
+        ["highlighted"]
+      )
+      expect(response.body.data.highlighted).toBe(true)
     })
   })
 
-  describe("addFeatured", () => {
-    test("adds featured category, syncs place.categories array, and returns updated place", async () => {
+  describe("DELETE", () => {
+    test("sets highlighted to false and returns updated place", async () => {
       findByIdWithAggregates.mockResolvedValueOnce({
         ...placeGenesisPlazaWithAggregatedAttributes,
-        categories: ["game"],
+        highlighted: true,
       })
-      addCategoryToPlace.mockResolvedValueOnce(undefined)
-      overrideCategories.mockResolvedValueOnce([] as any)
+      updatePlace.mockResolvedValueOnce([] as any)
 
-      const response = await addFeatured({
-        request: buildAuthenticatedRequest(),
+      const response = await featured({
+        request: buildAuthenticatedRequest("DELETE"),
         params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
         url: buildUrl(),
       } as any)
 
-      expect(addCategoryToPlace).toHaveBeenCalledWith(
-        placeGenesisPlazaWithAggregatedAttributes.id,
-        "featured"
+      expect(updatePlace).toHaveBeenCalledWith(
+        expect.objectContaining({ highlighted: false }),
+        ["highlighted"]
       )
-      expect(overrideCategories).toHaveBeenCalledWith(
-        placeGenesisPlazaWithAggregatedAttributes.id,
-        ["game", "featured"]
-      )
-      expect(response.body.data.categories).toEqual(["game", "featured"])
-    })
-
-    test("is a no-op when place is already featured", async () => {
-      findByIdWithAggregates.mockResolvedValueOnce({
-        ...placeGenesisPlazaWithAggregatedAttributes,
-        categories: ["featured", "game"],
-      })
-
-      const response = await addFeatured({
-        request: buildAuthenticatedRequest(),
-        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
-        url: buildUrl(),
-      } as any)
-
-      expect(addCategoryToPlace).not.toHaveBeenCalled()
-      expect(overrideCategories).not.toHaveBeenCalled()
-      expect(response.body.data.categories).toEqual(["featured", "game"])
-    })
-  })
-
-  describe("removeFeatured", () => {
-    test("removes featured category, syncs place.categories array, and returns updated place", async () => {
-      findByIdWithAggregates.mockResolvedValueOnce({
-        ...placeGenesisPlazaWithAggregatedAttributes,
-        categories: ["featured", "game"],
-      })
-      removeCategoryFromPlace.mockResolvedValueOnce(undefined)
-      overrideCategories.mockResolvedValueOnce([] as any)
-
-      const response = await removeFeatured({
-        request: buildAuthenticatedRequest(),
-        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
-        url: buildUrl(),
-      } as any)
-
-      expect(removeCategoryFromPlace).toHaveBeenCalledWith(
-        placeGenesisPlazaWithAggregatedAttributes.id,
-        "featured"
-      )
-      expect(overrideCategories).toHaveBeenCalledWith(
-        placeGenesisPlazaWithAggregatedAttributes.id,
-        ["game"]
-      )
-      expect(response.body.data.categories).toEqual(["game"])
-    })
-
-    test("is a no-op when place is not featured", async () => {
-      findByIdWithAggregates.mockResolvedValueOnce({
-        ...placeGenesisPlazaWithAggregatedAttributes,
-        categories: ["game"],
-      })
-
-      const response = await removeFeatured({
-        request: buildAuthenticatedRequest(),
-        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
-        url: buildUrl(),
-      } as any)
-
-      expect(removeCategoryFromPlace).not.toHaveBeenCalled()
-      expect(overrideCategories).not.toHaveBeenCalled()
-      expect(response.body.data.categories).toEqual(["game"])
+      expect(response.body.data.highlighted).toBe(false)
     })
   })
 })

--- a/src/entities/Place/routes/featured.test.ts
+++ b/src/entities/Place/routes/featured.test.ts
@@ -3,8 +3,10 @@ import { randomUUID } from "crypto"
 import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
 
 import { placeGenesisPlazaWithAggregatedAttributes } from "../../../__data__/placeGenesisPlazaWithAggregatedAttributes"
+import { worldPlaceParalaxWithAggregated } from "../../../__data__/world"
 import PlaceModel from "../model"
-import { featured } from "./featured"
+
+import type * as FeaturedModule from "./featured"
 
 const VALID_TOKEN = "test-service-token-12345"
 const place_id = randomUUID()
@@ -31,6 +33,16 @@ const buildAuthenticatedRequest = (method: "PUT" | "DELETE") => {
 
 const buildUrl = () => new URL("https://localhost/")
 
+let featurePlace: typeof FeaturedModule.featurePlace
+let unfeaturePlace: typeof FeaturedModule.unfeaturePlace
+
+beforeAll(async () => {
+  mockEnvToken = VALID_TOKEN
+  const mod = await import("./featured")
+  featurePlace = mod.featurePlace
+  unfeaturePlace = mod.unfeaturePlace
+})
+
 beforeEach(() => {
   mockEnvToken = VALID_TOKEN
 })
@@ -40,13 +52,14 @@ afterEach(() => {
   updatePlace.mockReset()
 })
 
-describe("featured", () => {
+describe("featured endpoints", () => {
   describe("authentication", () => {
     test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 401 when authorization header is missing",
       async (method) => {
+        const handler = method === "PUT" ? featurePlace : unfeaturePlace
         await expect(() =>
-          featured({
+          handler({
             request: new Request("/", { method }),
             params: { place_id },
             url: buildUrl(),
@@ -58,11 +71,12 @@ describe("featured", () => {
     test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 403 when authorization token is invalid",
       async (method) => {
+        const handler = method === "PUT" ? featurePlace : unfeaturePlace
         const request = new Request("/", { method })
         request.headers.set("Authorization", "Bearer invalid-token")
 
         await expect(() =>
-          featured({
+          handler({
             request,
             params: { place_id },
             url: buildUrl(),
@@ -76,13 +90,21 @@ describe("featured", () => {
       async (method) => {
         mockEnvToken = ""
 
-        await expect(() =>
-          featured({
-            request: buildAuthenticatedRequest(method),
-            params: { place_id },
-            url: buildUrl(),
-          } as any)
-        ).rejects.toThrow("Invalid Bearer Token")
+        await jest.isolateModulesAsync(async () => {
+          const freshModule = await import("./featured")
+          const handler =
+            method === "PUT"
+              ? freshModule.featurePlace
+              : freshModule.unfeaturePlace
+
+          await expect(() =>
+            handler({
+              request: buildAuthenticatedRequest(method),
+              params: { place_id },
+              url: buildUrl(),
+            } as any)
+          ).rejects.toThrow("Invalid Bearer Token")
+        })
       }
     )
   })
@@ -91,13 +113,14 @@ describe("featured", () => {
     test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 400 when place_id is not a valid UUID",
       async (method) => {
+        const handler = method === "PUT" ? featurePlace : unfeaturePlace
         await expect(() =>
-          featured({
+          handler({
             request: buildAuthenticatedRequest(method),
             params: { place_id: "invalid-uuid" },
             url: buildUrl(),
           } as any)
-        ).rejects.toThrow()
+        ).rejects.toThrow("Invalid data was sent to the server")
       }
     )
   })
@@ -106,10 +129,11 @@ describe("featured", () => {
     test.each([["PUT"], ["DELETE"]] as const)(
       "%s returns 404 when place does not exist",
       async (method) => {
+        const handler = method === "PUT" ? featurePlace : unfeaturePlace
         findByIdWithAggregates.mockResolvedValueOnce(null as any)
 
         await expect(() =>
-          featured({
+          handler({
             request: buildAuthenticatedRequest(method),
             params: { place_id },
             url: buildUrl(),
@@ -119,7 +143,7 @@ describe("featured", () => {
     )
   })
 
-  describe("PUT", () => {
+  describe("featurePlace", () => {
     test("sets highlighted to true and returns updated place", async () => {
       findByIdWithAggregates.mockResolvedValueOnce({
         ...placeGenesisPlazaWithAggregatedAttributes,
@@ -127,7 +151,7 @@ describe("featured", () => {
       })
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const response = await featured({
+      const response = await featurePlace({
         request: buildAuthenticatedRequest("PUT"),
         params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
         url: buildUrl(),
@@ -139,9 +163,49 @@ describe("featured", () => {
       )
       expect(response.body.data.highlighted).toBe(true)
     })
+
+    test("sets highlighted to true on a world place", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...worldPlaceParalaxWithAggregated,
+        highlighted: false,
+      })
+      updatePlace.mockResolvedValueOnce([] as any)
+
+      const response = await featurePlace({
+        request: buildAuthenticatedRequest("PUT"),
+        params: { place_id: worldPlaceParalaxWithAggregated.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(updatePlace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlighted: true,
+          world: true,
+          world_name: worldPlaceParalaxWithAggregated.world_name,
+        }),
+        ["highlighted"]
+      )
+      expect(response.body.data.highlighted).toBe(true)
+    })
+
+    test("propagates errors from updatePlace", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        highlighted: false,
+      })
+      updatePlace.mockRejectedValueOnce(new Error("db write failed"))
+
+      await expect(() =>
+        featurePlace({
+          request: buildAuthenticatedRequest("PUT"),
+          params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("db write failed")
+    })
   })
 
-  describe("DELETE", () => {
+  describe("unfeaturePlace", () => {
     test("sets highlighted to false and returns updated place", async () => {
       findByIdWithAggregates.mockResolvedValueOnce({
         ...placeGenesisPlazaWithAggregatedAttributes,
@@ -149,7 +213,7 @@ describe("featured", () => {
       })
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const response = await featured({
+      const response = await unfeaturePlace({
         request: buildAuthenticatedRequest("DELETE"),
         params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
         url: buildUrl(),
@@ -160,6 +224,46 @@ describe("featured", () => {
         ["highlighted"]
       )
       expect(response.body.data.highlighted).toBe(false)
+    })
+
+    test("sets highlighted to false on a world place", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...worldPlaceParalaxWithAggregated,
+        highlighted: true,
+      })
+      updatePlace.mockResolvedValueOnce([] as any)
+
+      const response = await unfeaturePlace({
+        request: buildAuthenticatedRequest("DELETE"),
+        params: { place_id: worldPlaceParalaxWithAggregated.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(updatePlace).toHaveBeenCalledWith(
+        expect.objectContaining({
+          highlighted: false,
+          world: true,
+          world_name: worldPlaceParalaxWithAggregated.world_name,
+        }),
+        ["highlighted"]
+      )
+      expect(response.body.data.highlighted).toBe(false)
+    })
+
+    test("propagates errors from updatePlace", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        highlighted: true,
+      })
+      updatePlace.mockRejectedValueOnce(new Error("db write failed"))
+
+      await expect(() =>
+        unfeaturePlace({
+          request: buildAuthenticatedRequest("DELETE"),
+          params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("db write failed")
     })
   })
 })

--- a/src/entities/Place/routes/featured.test.ts
+++ b/src/entities/Place/routes/featured.test.ts
@@ -1,0 +1,229 @@
+import { randomUUID } from "crypto"
+
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+
+import { placeGenesisPlazaWithAggregatedAttributes } from "../../../__data__/placeGenesisPlazaWithAggregatedAttributes"
+import PlaceCategories from "../../PlaceCategories/model"
+import PlaceModel from "../model"
+import { addFeatured, removeFeatured } from "./featured"
+
+const VALID_TOKEN = "test-service-token-12345"
+const place_id = randomUUID()
+
+let mockEnvToken: string | undefined = VALID_TOKEN
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "PLACES_ADMIN_AUTH_TOKEN") {
+      return mockEnvToken ?? defaultValue
+    }
+    return defaultValue
+  })
+})
+
+const findByIdWithAggregates = jest.spyOn(PlaceModel, "findByIdWithAggregates")
+const overrideCategories = jest.spyOn(PlaceModel, "overrideCategories")
+const addCategoryToPlace = jest.spyOn(PlaceCategories, "addCategoryToPlace")
+const removeCategoryFromPlace = jest.spyOn(
+  PlaceCategories,
+  "removeCategoryFromPlace"
+)
+
+const buildAuthenticatedRequest = () => {
+  const request = new Request("/")
+  request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
+  return request
+}
+
+const buildUrl = () => new URL("https://localhost/")
+
+beforeEach(() => {
+  mockEnvToken = VALID_TOKEN
+})
+
+afterEach(() => {
+  findByIdWithAggregates.mockReset()
+  overrideCategories.mockReset()
+  addCategoryToPlace.mockReset()
+  removeCategoryFromPlace.mockReset()
+})
+
+describe("featured", () => {
+  describe("authentication", () => {
+    test.each([
+      ["addFeatured", addFeatured],
+      ["removeFeatured", removeFeatured],
+    ])(
+      "%s returns 401 when authorization header is missing",
+      async (_, handler) => {
+        await expect(() =>
+          handler({
+            request: new Request("/"),
+            params: { place_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow("Missing Authorization")
+      }
+    )
+
+    test.each([
+      ["addFeatured", addFeatured],
+      ["removeFeatured", removeFeatured],
+    ])(
+      "%s returns 403 when authorization token is invalid",
+      async (_, handler) => {
+        const request = new Request("/")
+        request.headers.set("Authorization", "Bearer invalid-token")
+
+        await expect(() =>
+          handler({
+            request,
+            params: { place_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow("Invalid Bearer Token")
+      }
+    )
+
+    test.each([
+      ["addFeatured", addFeatured],
+      ["removeFeatured", removeFeatured],
+    ])(
+      "%s rejects request when PLACES_ADMIN_AUTH_TOKEN is not configured",
+      async (_, handler) => {
+        mockEnvToken = ""
+
+        await expect(() =>
+          handler({
+            request: buildAuthenticatedRequest(),
+            params: { place_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow("Invalid Bearer Token")
+      }
+    )
+  })
+
+  describe("validation", () => {
+    test.each([
+      ["addFeatured", addFeatured],
+      ["removeFeatured", removeFeatured],
+    ])(
+      "%s returns 400 when place_id is not a valid UUID",
+      async (_, handler) => {
+        await expect(() =>
+          handler({
+            request: buildAuthenticatedRequest(),
+            params: { place_id: "invalid-uuid" },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow()
+      }
+    )
+  })
+
+  describe("place lookup", () => {
+    test.each([
+      ["addFeatured", addFeatured],
+      ["removeFeatured", removeFeatured],
+    ])("%s returns 404 when place does not exist", async (_, handler) => {
+      findByIdWithAggregates.mockResolvedValueOnce(null as any)
+
+      await expect(() =>
+        handler({
+          request: buildAuthenticatedRequest(),
+          params: { place_id },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow(`Not found place "${place_id}"`)
+    })
+  })
+
+  describe("addFeatured", () => {
+    test("adds featured category, syncs place.categories array, and returns updated place", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        categories: ["game"],
+      })
+      addCategoryToPlace.mockResolvedValueOnce(undefined)
+      overrideCategories.mockResolvedValueOnce([] as any)
+
+      const response = await addFeatured({
+        request: buildAuthenticatedRequest(),
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(addCategoryToPlace).toHaveBeenCalledWith(
+        placeGenesisPlazaWithAggregatedAttributes.id,
+        "featured"
+      )
+      expect(overrideCategories).toHaveBeenCalledWith(
+        placeGenesisPlazaWithAggregatedAttributes.id,
+        ["game", "featured"]
+      )
+      expect(response.body.data.categories).toEqual(["game", "featured"])
+    })
+
+    test("is a no-op when place is already featured", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        categories: ["featured", "game"],
+      })
+
+      const response = await addFeatured({
+        request: buildAuthenticatedRequest(),
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(addCategoryToPlace).not.toHaveBeenCalled()
+      expect(overrideCategories).not.toHaveBeenCalled()
+      expect(response.body.data.categories).toEqual(["featured", "game"])
+    })
+  })
+
+  describe("removeFeatured", () => {
+    test("removes featured category, syncs place.categories array, and returns updated place", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        categories: ["featured", "game"],
+      })
+      removeCategoryFromPlace.mockResolvedValueOnce(undefined)
+      overrideCategories.mockResolvedValueOnce([] as any)
+
+      const response = await removeFeatured({
+        request: buildAuthenticatedRequest(),
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(removeCategoryFromPlace).toHaveBeenCalledWith(
+        placeGenesisPlazaWithAggregatedAttributes.id,
+        "featured"
+      )
+      expect(overrideCategories).toHaveBeenCalledWith(
+        placeGenesisPlazaWithAggregatedAttributes.id,
+        ["game"]
+      )
+      expect(response.body.data.categories).toEqual(["game"])
+    })
+
+    test("is a no-op when place is not featured", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        categories: ["game"],
+      })
+
+      const response = await removeFeatured({
+        request: buildAuthenticatedRequest(),
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(removeCategoryFromPlace).not.toHaveBeenCalled()
+      expect(overrideCategories).not.toHaveBeenCalled()
+      expect(response.body.data.categories).toEqual(["game"])
+    })
+  })
+})

--- a/src/entities/Place/routes/featured.ts
+++ b/src/entities/Place/routes/featured.ts
@@ -1,0 +1,75 @@
+import withBearerToken from "decentraland-gatsby/dist/entities/Auth/routes/withBearerToken"
+import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
+import ApiResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ApiResponse"
+import ErrorResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ErrorResponse"
+import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Response"
+import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
+import env from "decentraland-gatsby/dist/utils/env"
+
+import PlaceCategories from "../../PlaceCategories/model"
+import { createWkcValidator } from "../../shared/validate"
+import PlaceModel from "../model"
+import { getPlaceParamsSchema } from "../schemas"
+import { AggregatePlaceAttributes, GetPlaceParams } from "../types"
+
+const FEATURED_CATEGORY = "featured"
+
+type FeaturedOperation = "add" | "remove"
+
+const validateParams = createWkcValidator<GetPlaceParams>(
+  getPlaceParamsSchema as AjvObjectSchema
+)
+
+async function handleFeatured(
+  ctx: Context<{ place_id: string }, "request" | "params">,
+  operation: FeaturedOperation
+): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
+  const token = env("PLACES_ADMIN_AUTH_TOKEN", "")
+  await withBearerToken({ tokens: token ? [token] : [], optional: false })(ctx)
+
+  const params = await validateParams(ctx.params)
+
+  const place = await PlaceModel.findByIdWithAggregates(params.place_id, {
+    user: undefined,
+  })
+
+  if (!place) {
+    throw new ErrorResponse(
+      Response.NotFound,
+      `Not found place "${params.place_id}"`
+    )
+  }
+
+  const categories = new Set(place.categories ?? [])
+  const hasFeatured = categories.has(FEATURED_CATEGORY)
+  const shouldAdd = operation === "add" && !hasFeatured
+  const shouldRemove = operation === "remove" && hasFeatured
+
+  if (!shouldAdd && !shouldRemove) {
+    return new ApiResponse(place)
+  }
+
+  if (shouldAdd) {
+    await PlaceCategories.addCategoryToPlace(params.place_id, FEATURED_CATEGORY)
+    categories.add(FEATURED_CATEGORY)
+  } else {
+    await PlaceCategories.removeCategoryFromPlace(
+      params.place_id,
+      FEATURED_CATEGORY
+    )
+    categories.delete(FEATURED_CATEGORY)
+  }
+
+  const updatedCategories = Array.from(categories)
+  await PlaceModel.overrideCategories(params.place_id, updatedCategories)
+
+  return new ApiResponse({ ...place, categories: updatedCategories })
+}
+
+export const addFeatured = (
+  ctx: Context<{ place_id: string }, "request" | "params">
+) => handleFeatured(ctx, "add")
+
+export const removeFeatured = (
+  ctx: Context<{ place_id: string }, "request" | "params">
+) => handleFeatured(ctx, "remove")

--- a/src/entities/Place/routes/featured.ts
+++ b/src/entities/Place/routes/featured.ts
@@ -11,15 +11,24 @@ import PlaceModel from "../model"
 import { getPlaceParamsSchema } from "../schemas"
 import { AggregatePlaceAttributes, GetPlaceParams } from "../types"
 
+const ADMIN_TOKEN = env("PLACES_ADMIN_AUTH_TOKEN", "")
+
+const requireAdminToken = withBearerToken({
+  tokens: ADMIN_TOKEN ? [ADMIN_TOKEN] : [],
+  optional: false,
+})
+
 const validateParams = createWkcValidator<GetPlaceParams>(
   getPlaceParamsSchema as AjvObjectSchema
 )
 
-export async function featured(
-  ctx: Context<{ place_id: string }, "request" | "params">
+// The `/featured` endpoints toggle the `highlighted` DB column, renamed from
+// `featured` to `highlighted` in migration 1667844930518_add-highlighted.ts.
+async function setHighlighted(
+  ctx: Context<{ place_id: string }, "request" | "params">,
+  highlighted: boolean
 ): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
-  const token = env("PLACES_ADMIN_AUTH_TOKEN", "")
-  await withBearerToken({ tokens: token ? [token] : [], optional: false })(ctx)
+  await requireAdminToken(ctx)
 
   const params = await validateParams(ctx.params)
 
@@ -34,9 +43,20 @@ export async function featured(
     )
   }
 
-  const highlighted = ctx.request.method.toUpperCase() === "PUT"
   const newPlace = { ...place, highlighted }
   await PlaceModel.updatePlace(newPlace, ["highlighted"])
 
   return new ApiResponse(newPlace)
+}
+
+export function featurePlace(
+  ctx: Context<{ place_id: string }, "request" | "params">
+): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
+  return setHighlighted(ctx, true)
+}
+
+export function unfeaturePlace(
+  ctx: Context<{ place_id: string }, "request" | "params">
+): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
+  return setHighlighted(ctx, false)
 }

--- a/src/entities/Place/routes/featured.ts
+++ b/src/entities/Place/routes/featured.ts
@@ -6,23 +6,17 @@ import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Respo
 import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
 import env from "decentraland-gatsby/dist/utils/env"
 
-import PlaceCategories from "../../PlaceCategories/model"
 import { createWkcValidator } from "../../shared/validate"
 import PlaceModel from "../model"
 import { getPlaceParamsSchema } from "../schemas"
 import { AggregatePlaceAttributes, GetPlaceParams } from "../types"
 
-const FEATURED_CATEGORY = "featured"
-
-type FeaturedOperation = "add" | "remove"
-
 const validateParams = createWkcValidator<GetPlaceParams>(
   getPlaceParamsSchema as AjvObjectSchema
 )
 
-async function handleFeatured(
-  ctx: Context<{ place_id: string }, "request" | "params">,
-  operation: FeaturedOperation
+export async function featured(
+  ctx: Context<{ place_id: string }, "request" | "params">
 ): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
   const token = env("PLACES_ADMIN_AUTH_TOKEN", "")
   await withBearerToken({ tokens: token ? [token] : [], optional: false })(ctx)
@@ -40,36 +34,9 @@ async function handleFeatured(
     )
   }
 
-  const categories = new Set(place.categories ?? [])
-  const hasFeatured = categories.has(FEATURED_CATEGORY)
-  const shouldAdd = operation === "add" && !hasFeatured
-  const shouldRemove = operation === "remove" && hasFeatured
+  const highlighted = ctx.request.method.toUpperCase() === "PUT"
+  const newPlace = { ...place, highlighted }
+  await PlaceModel.updatePlace(newPlace, ["highlighted"])
 
-  if (!shouldAdd && !shouldRemove) {
-    return new ApiResponse(place)
-  }
-
-  if (shouldAdd) {
-    await PlaceCategories.addCategoryToPlace(params.place_id, FEATURED_CATEGORY)
-    categories.add(FEATURED_CATEGORY)
-  } else {
-    await PlaceCategories.removeCategoryFromPlace(
-      params.place_id,
-      FEATURED_CATEGORY
-    )
-    categories.delete(FEATURED_CATEGORY)
-  }
-
-  const updatedCategories = Array.from(categories)
-  await PlaceModel.overrideCategories(params.place_id, updatedCategories)
-
-  return new ApiResponse({ ...place, categories: updatedCategories })
+  return new ApiResponse(newPlace)
 }
-
-export const addFeatured = (
-  ctx: Context<{ place_id: string }, "request" | "params">
-) => handleFeatured(ctx, "add")
-
-export const removeFeatured = (
-  ctx: Context<{ place_id: string }, "request" | "params">
-) => handleFeatured(ctx, "remove")

--- a/src/entities/Place/routes/index.ts
+++ b/src/entities/Place/routes/index.ts
@@ -2,7 +2,7 @@ import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCor
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
-import { addFeatured, removeFeatured } from "./featured"
+import { featured } from "./featured"
 import { getPlace } from "./getPlace"
 import { getPlaceCategories } from "./getPlaceCategories"
 import { getPlaceList } from "./getPlaceList"
@@ -39,7 +39,7 @@ export default routes((router) => {
   router.put("/places/:place_id/ranking", updateRanking)
   router.put("/places/:place_id/highlight", updateHighlight)
   router.get("/places/:place_id/categories", getPlaceCategories)
-  router.put("/places/:place_id/featured", addFeatured)
-  router.delete("/places/:place_id/featured", removeFeatured)
+  router.put("/places/:place_id/featured", featured)
+  router.delete("/places/:place_id/featured", featured)
   router.post("/places/status", getPlaceStatusListById)
 }, {})

--- a/src/entities/Place/routes/index.ts
+++ b/src/entities/Place/routes/index.ts
@@ -2,7 +2,7 @@ import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCor
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
-import { featured } from "./featured"
+import { featurePlace, unfeaturePlace } from "./featured"
 import { getPlace } from "./getPlace"
 import { getPlaceCategories } from "./getPlaceCategories"
 import { getPlaceList } from "./getPlaceList"
@@ -39,7 +39,7 @@ export default routes((router) => {
   router.put("/places/:place_id/ranking", updateRanking)
   router.put("/places/:place_id/highlight", updateHighlight)
   router.get("/places/:place_id/categories", getPlaceCategories)
-  router.put("/places/:place_id/featured", featured)
-  router.delete("/places/:place_id/featured", featured)
+  router.put("/places/:place_id/featured", featurePlace)
+  router.delete("/places/:place_id/featured", unfeaturePlace)
   router.post("/places/status", getPlaceStatusListById)
 }, {})

--- a/src/entities/Place/routes/index.ts
+++ b/src/entities/Place/routes/index.ts
@@ -2,6 +2,7 @@ import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCor
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
+import { addFeatured, removeFeatured } from "./featured"
 import { getPlace } from "./getPlace"
 import { getPlaceCategories } from "./getPlaceCategories"
 import { getPlaceList } from "./getPlaceList"
@@ -38,5 +39,7 @@ export default routes((router) => {
   router.put("/places/:place_id/ranking", updateRanking)
   router.put("/places/:place_id/highlight", updateHighlight)
   router.get("/places/:place_id/categories", getPlaceCategories)
+  router.put("/places/:place_id/featured", addFeatured)
+  router.delete("/places/:place_id/featured", removeFeatured)
   router.post("/places/status", getPlaceStatusListById)
 }, {})

--- a/src/entities/PlaceCategories/model.ts
+++ b/src/entities/PlaceCategories/model.ts
@@ -35,7 +35,7 @@ export default class PlaceCategories extends Model<PlaceCategoriesAttributes> {
   static async addCategoryToPlace(placeId: string, category: string) {
     const query = SQL`INSERT INTO ${table(
       PlaceCategories
-    )} (place_id, category_id) VALUES (${placeId}, ${category}) ON CONFLICT DO NOTHING`
+    )} (place_id, category_id) VALUES (${placeId}, ${category})`
 
     await PlaceCategories.namedQuery("add_category_to_place", query)
   }

--- a/src/entities/PlaceCategories/model.ts
+++ b/src/entities/PlaceCategories/model.ts
@@ -35,7 +35,7 @@ export default class PlaceCategories extends Model<PlaceCategoriesAttributes> {
   static async addCategoryToPlace(placeId: string, category: string) {
     const query = SQL`INSERT INTO ${table(
       PlaceCategories
-    )} (place_id, category_id) VALUES (${placeId}, ${category})`
+    )} (place_id, category_id) VALUES (${placeId}, ${category}) ON CONFLICT DO NOTHING`
 
     await PlaceCategories.namedQuery("add_category_to_place", query)
   }


### PR DESCRIPTION
Adds two bearer-token-protected admin endpoints to toggle the `highlighted` flag on a place without going through the wallet-authenticated `/highlight` flow.

- `PUT /places/:place_id/featured` → `featurePlace`: sets `highlighted = true`.
- `DELETE /places/:place_id/featured` → `unfeaturePlace`: sets `highlighted = false`.

Both require the `PLACES_ADMIN_AUTH_TOKEN` bearer token and take no request body. They return the updated aggregate place. `highlighted` is the DB column renamed from `featured` in migration `1667844930518_add-highlighted.ts`.

Each verb now maps to its own named handler, sharing a common `setHighlighted(ctx, boolean)` helper. The bearer-token middleware and admin token are resolved once at module load instead of per request.

Tests cover auth (missing header, invalid token, unconfigured env), validation (non-UUID `place_id`), 404 on missing place, both PUT/DELETE happy paths for regular and world places, and propagation of `updatePlace` rejections.

Also includes a small fix to `createPlaceFromDefaultPlaces` test so it no longer depends on the exact list of Genesis Plaza positions returned by the live catalyst.