### PR TITLE
feat: add admin PUT/DELETE /worlds/:world_id/featured endpoints

### DIFF
--- a/src/entities/World/routes/featured.test.ts
+++ b/src/entities/World/routes/featured.test.ts
@@ -1,0 +1,238 @@
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+import { SceneContentRating } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
+
+import WorldModel from "../model"
+import { AggregateWorldAttributes } from "../types"
+
+import type * as FeaturedModule from "./featured"
+
+const VALID_TOKEN = "test-service-token-12345"
+const world_id = "brai.dcl.eth"
+
+let mockEnvToken: string | undefined = VALID_TOKEN
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "PLACES_ADMIN_AUTH_TOKEN") {
+      return mockEnvToken ?? defaultValue
+    }
+    return defaultValue
+  })
+})
+
+const baseAggregateWorld: AggregateWorldAttributes = {
+  id: world_id,
+  world_name: world_id,
+  title: "The house of dToxic",
+  description: null,
+  image: null,
+  owner: null,
+  content_rating: SceneContentRating.TEEN,
+  categories: [],
+  likes: 0,
+  dislikes: 0,
+  favorites: 0,
+  like_rate: 0.5,
+  like_score: 0,
+  created_at: new Date(),
+  updated_at: new Date(),
+  show_in_places: true,
+  single_player: false,
+  skybox_time: null,
+  is_private: false,
+  highlighted: false,
+  highlighted_image: null,
+  ranking: null,
+  user_like: false,
+  user_dislike: false,
+  user_favorite: false,
+  user_visits: 0,
+  world: true,
+  contact_name: null,
+  base_position: "0,0",
+  deployed_at: null,
+}
+
+const findByIdWithAggregates = jest.spyOn(WorldModel, "findByIdWithAggregates")
+const updateHighlighted = jest.spyOn(WorldModel, "updateHighlighted")
+
+const buildAuthenticatedRequest = (method: "PUT" | "DELETE") => {
+  const request = new Request("/", { method })
+  request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
+  return request
+}
+
+const buildUrl = () => new URL("https://localhost/")
+
+let featureWorld: typeof FeaturedModule.featureWorld
+let unfeatureWorld: typeof FeaturedModule.unfeatureWorld
+
+beforeAll(async () => {
+  mockEnvToken = VALID_TOKEN
+  const mod = await import("./featured")
+  featureWorld = mod.featureWorld
+  unfeatureWorld = mod.unfeatureWorld
+})
+
+beforeEach(() => {
+  mockEnvToken = VALID_TOKEN
+})
+
+afterEach(() => {
+  findByIdWithAggregates.mockReset()
+  updateHighlighted.mockReset()
+})
+
+describe("world featured endpoints", () => {
+  describe("authentication", () => {
+    test.each([["PUT"], ["DELETE"]] as const)(
+      "%s returns 401 when authorization header is missing",
+      async (method) => {
+        const handler = method === "PUT" ? featureWorld : unfeatureWorld
+        await expect(() =>
+          handler({
+            request: new Request("/", { method }),
+            params: { world_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow("Missing Authorization")
+      }
+    )
+
+    test.each([["PUT"], ["DELETE"]] as const)(
+      "%s returns 403 when authorization token is invalid",
+      async (method) => {
+        const handler = method === "PUT" ? featureWorld : unfeatureWorld
+        const request = new Request("/", { method })
+        request.headers.set("Authorization", "Bearer invalid-token")
+
+        await expect(() =>
+          handler({
+            request,
+            params: { world_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow("Invalid Bearer Token")
+      }
+    )
+
+    test.each([["PUT"], ["DELETE"]] as const)(
+      "%s rejects request when PLACES_ADMIN_AUTH_TOKEN is not configured",
+      async (method) => {
+        mockEnvToken = ""
+
+        await jest.isolateModulesAsync(async () => {
+          const freshModule = await import("./featured")
+          const handler =
+            method === "PUT"
+              ? freshModule.featureWorld
+              : freshModule.unfeatureWorld
+
+          await expect(() =>
+            handler({
+              request: buildAuthenticatedRequest(method),
+              params: { world_id },
+              url: buildUrl(),
+            } as any)
+          ).rejects.toThrow("Invalid Bearer Token")
+        })
+      }
+    )
+  })
+
+  describe("world lookup", () => {
+    test.each([["PUT"], ["DELETE"]] as const)(
+      "%s returns 404 when world does not exist",
+      async (method) => {
+        const handler = method === "PUT" ? featureWorld : unfeatureWorld
+        findByIdWithAggregates.mockResolvedValueOnce(null)
+
+        await expect(() =>
+          handler({
+            request: buildAuthenticatedRequest(method),
+            params: { world_id },
+            url: buildUrl(),
+          } as any)
+        ).rejects.toThrow(`Not found world "${world_id}"`)
+      }
+    )
+  })
+
+  describe("featureWorld", () => {
+    test("sets highlighted to true and returns updated world", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...baseAggregateWorld,
+        highlighted: false,
+      })
+      updateHighlighted.mockResolvedValueOnce()
+
+      const response = await featureWorld({
+        request: buildAuthenticatedRequest("PUT"),
+        params: { world_id: baseAggregateWorld.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(updateHighlighted).toHaveBeenCalledWith(
+        baseAggregateWorld.id,
+        true
+      )
+      expect(response.body.data.highlighted).toBe(true)
+      expect(response.body.data.world_name).toBe(baseAggregateWorld.world_name)
+    })
+
+    test("propagates errors from updateHighlighted", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...baseAggregateWorld,
+        highlighted: false,
+      })
+      updateHighlighted.mockRejectedValueOnce(new Error("db write failed"))
+
+      await expect(() =>
+        featureWorld({
+          request: buildAuthenticatedRequest("PUT"),
+          params: { world_id: baseAggregateWorld.id },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("db write failed")
+    })
+  })
+
+  describe("unfeatureWorld", () => {
+    test("sets highlighted to false and returns updated world", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...baseAggregateWorld,
+        highlighted: true,
+      })
+      updateHighlighted.mockResolvedValueOnce()
+
+      const response = await unfeatureWorld({
+        request: buildAuthenticatedRequest("DELETE"),
+        params: { world_id: baseAggregateWorld.id },
+        url: buildUrl(),
+      } as any)
+
+      expect(updateHighlighted).toHaveBeenCalledWith(
+        baseAggregateWorld.id,
+        false
+      )
+      expect(response.body.data.highlighted).toBe(false)
+      expect(response.body.data.world_name).toBe(baseAggregateWorld.world_name)
+    })
+
+    test("propagates errors from updateHighlighted", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce({
+        ...baseAggregateWorld,
+        highlighted: true,
+      })
+      updateHighlighted.mockRejectedValueOnce(new Error("db write failed"))
+
+      await expect(() =>
+        unfeatureWorld({
+          request: buildAuthenticatedRequest("DELETE"),
+          params: { world_id: baseAggregateWorld.id },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("db write failed")
+    })
+  })
+})

--- a/src/entities/World/routes/featured.ts
+++ b/src/entities/World/routes/featured.ts
@@ -1,0 +1,59 @@
+import withBearerToken from "decentraland-gatsby/dist/entities/Auth/routes/withBearerToken"
+import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
+import ApiResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ApiResponse"
+import ErrorResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ErrorResponse"
+import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Response"
+import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
+import env from "decentraland-gatsby/dist/utils/env"
+
+import { createWkcValidator } from "../../shared/validate"
+import WorldModel from "../model"
+import { getWorldParamsSchema } from "../schemas"
+import { AggregateWorldAttributes, GetWorldParams } from "../types"
+
+const ADMIN_TOKEN = env("PLACES_ADMIN_AUTH_TOKEN", "")
+
+const requireAdminToken = withBearerToken({
+  tokens: ADMIN_TOKEN ? [ADMIN_TOKEN] : [],
+  optional: false,
+})
+
+const validateParams = createWkcValidator<GetWorldParams>(
+  getWorldParamsSchema as AjvObjectSchema
+)
+
+async function setHighlighted(
+  ctx: Context<{ world_id: string }, "request" | "params">,
+  highlighted: boolean
+): Promise<ApiResponse<AggregateWorldAttributes, {}>> {
+  await requireAdminToken(ctx)
+
+  const params = await validateParams(ctx.params)
+
+  const world = await WorldModel.findByIdWithAggregates(params.world_id, {
+    user: undefined,
+  })
+
+  if (!world) {
+    throw new ErrorResponse(
+      Response.NotFound,
+      `Not found world "${params.world_id}"`
+    )
+  }
+
+  await WorldModel.updateHighlighted(params.world_id, highlighted)
+
+  return new ApiResponse({ ...world, highlighted })
+}
+
+export function featureWorld(
+  ctx: Context<{ world_id: string }, "request" | "params">
+): Promise<ApiResponse<AggregateWorldAttributes, {}>> {
+  return setHighlighted(ctx, true)
+}
+
+export function unfeatureWorld(
+  ctx: Context<{ world_id: string }, "request" | "params">
+): Promise<ApiResponse<AggregateWorldAttributes, {}>> {
+  return setHighlighted(ctx, false)
+}

--- a/src/entities/World/routes/index.ts
+++ b/src/entities/World/routes/index.ts
@@ -2,6 +2,7 @@ import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCor
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
+import { featureWorld, unfeatureWorld } from "./featured"
 import { getWorld } from "./getWorld"
 import { getWorldList } from "./getWorldList"
 import { getWorldNamesList } from "./getWorldNamesList"
@@ -39,4 +40,6 @@ export default routes((router) => {
   router.put("/worlds/:world_id/highlight", updateWorldHighlight)
   router.put("/worlds/:world_id/ranking", updateWorldRanking)
   router.put("/worlds/:world_id/rating", updateWorldRating)
+  router.put("/worlds/:world_id/featured", featureWorld)
+  router.delete("/worlds/:world_id/featured", unfeatureWorld)
 }, {})


### PR DESCRIPTION
Mirrors the places featured endpoints (#833) for worlds so admin bearer-token callers can toggle a world's `highlighted` flag without a signed fetch.

- `PUT /worlds/:world_id/featured` sets `highlighted` to `true`
- `DELETE /worlds/:world_id/featured` sets `highlighted` to `false`
- Both require `PLACES_ADMIN_AUTH_TOKEN` (shared with the places admin endpoints)
- Returns the updated aggregate world

## Test plan
- [x] Unit tests for auth (missing/invalid token, unconfigured env)
- [x] Unit tests for 404 when world does not exist
- [x] Unit tests for happy path (true/false) and error propagation
- [ ] Smoke test against `brai.dcl.eth` in zone once deployed