### PR TITLE
feat: point slack notification links to /whats-on

### DIFF
--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -6,6 +6,8 @@ import {
   placesWithUserCount,
   placesWithUserVisits,
   siteUrl,
+  whatsOnPlaceUrl,
+  whatsOnWorldUrl,
 } from "./utils"
 import { contentEntitySceneGenesisPlaza } from "../../__data__/contentEntitySceneGenesisPlaza"
 import { genesisPlazaThumbnailMap } from "../../__data__/entities"
@@ -14,7 +16,10 @@ import { placeGenesisPlaza } from "../../__data__/placeGenesisPlaza"
 import { placeGenesisPlazaWithAggregatedAttributes } from "../../__data__/placeGenesisPlazaWithAggregatedAttributes"
 import { sceneStatsGenesisPlaza } from "../../__data__/sceneStatsGenesisPlaza"
 import { sqsMessageWorld } from "../../__data__/sqs"
-import { worldContentEntitySceneParalax } from "../../__data__/world"
+import {
+  worldContentEntitySceneParalax,
+  worldPlaceParalax,
+} from "../../__data__/world"
 
 describe("Instance of URL", () => {
   test("should return an URL instance of a place in places", () => {
@@ -29,6 +34,22 @@ describe("Instance of URL", () => {
     const url = siteUrl()
     expect(url).toBeInstanceOf(URL)
     expect(url.toString()).toBe("https://decentraland.org/places/")
+  })
+
+  test("should return a whats-on URL for a place", () => {
+    const url = whatsOnPlaceUrl(placeGenesisPlaza)
+    expect(url).toBeInstanceOf(URL)
+    expect(url.toString()).toBe(
+      "https://decentraland.org/whats-on?position=0.0"
+    )
+  })
+
+  test("should return a whats-on URL for a world", () => {
+    const url = whatsOnWorldUrl(worldPlaceParalax)
+    expect(url).toBeInstanceOf(URL)
+    expect(url.toString()).toBe(
+      "https://decentraland.org/whats-on?world=paralax.dcl.eth"
+    )
   })
 })
 

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -37,22 +37,21 @@ export function worldUrl(entity: AnyEntityAttributes) {
   return target
 }
 
-export function whatsOnPlaceUrl(place: PlaceAttributes) {
+function whatsOnUrl(param: "position" | "world", value: string) {
   const target = new URL(
     env("PLACES_BASE_URL", "https://decentraland.org/places")
   )
   target.pathname = "/whats-on"
-  target.searchParams.set("position", toCanonicalPosition(place.base_position)!)
+  target.searchParams.set(param, value)
   return target
 }
 
+export function whatsOnPlaceUrl(place: PlaceAttributes) {
+  return whatsOnUrl("position", toCanonicalPosition(place.base_position)!)
+}
+
 export function whatsOnWorldUrl(entity: AnyEntityAttributes) {
-  const target = new URL(
-    env("PLACES_BASE_URL", "https://decentraland.org/places")
-  )
-  target.pathname = "/whats-on"
-  target.searchParams.set("world", entity.world_name!)
-  return target
+  return whatsOnUrl("world", entity.world_name!)
 }
 
 export function siteUrl(pathname = "") {

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -37,6 +37,24 @@ export function worldUrl(entity: AnyEntityAttributes) {
   return target
 }
 
+export function whatsOnPlaceUrl(place: PlaceAttributes) {
+  const target = new URL(
+    env("PLACES_BASE_URL", "https://decentraland.org/places")
+  )
+  target.pathname = "/whats-on"
+  target.searchParams.set("position", toCanonicalPosition(place.base_position)!)
+  return target
+}
+
+export function whatsOnWorldUrl(entity: AnyEntityAttributes) {
+  const target = new URL(
+    env("PLACES_BASE_URL", "https://decentraland.org/places")
+  )
+  target.pathname = "/whats-on"
+  target.searchParams.set("world", entity.world_name!)
+  return target
+}
+
 export function siteUrl(pathname = "") {
   const target = new URL(
     env("PLACES_BASE_URL", "https://decentraland.org/places")

--- a/src/entities/Slack/utils.ts
+++ b/src/entities/Slack/utils.ts
@@ -5,7 +5,7 @@ import isURL from "validator/lib/isURL"
 
 import { DeploymentToSqs } from "../CheckScenes/task/consumer"
 import { PlaceAttributes } from "../Place/types"
-import { placeUrl, worldUrl } from "../Place/utils"
+import { whatsOnPlaceUrl, whatsOnWorldUrl } from "../Place/utils"
 import { AnyEntityAttributes, isWorld } from "../shared/entityTypes"
 
 const SLACK_WEBHOOK = env("SLACK_WEBHOOK", "")
@@ -35,8 +35,8 @@ export async function notifyNewPlace(
           type: "mrkdwn",
           text: `:tada: New ${place.world ? "world" : "place"} added: ${
             place.world
-              ? `<${worldUrl(place)}|${place.world_name}>`
-              : `<${placeUrl(place)}|${place.base_position}>`
+              ? `<${whatsOnWorldUrl(place)}|${place.world_name}>`
+              : `<${whatsOnPlaceUrl(place)}|${place.base_position}>`
           }`,
         },
       },
@@ -75,8 +75,8 @@ export async function notifyUpdatePlace(
             place.world ? "world" : "Place"
           } updated: ${
             place.world
-              ? `<${worldUrl(place)}|${place.world_name}>`
-              : `<${placeUrl(place)}|${place.base_position}>`
+              ? `<${whatsOnWorldUrl(place)}|${place.world_name}>`
+              : `<${whatsOnPlaceUrl(place)}|${place.base_position}>`
           }`,
         },
       },
@@ -205,8 +205,8 @@ export async function notifyDowngradeRating(
             isWorldEntity ? "world" : "place"
           } updated trying to downgrade rating: ${
             isWorldEntity
-              ? `<${worldUrl(place)}|${place.world_name}>`
-              : `<${placeUrl(place as PlaceAttributes)}|${
+              ? `<${whatsOnWorldUrl(place)}|${place.world_name}>`
+              : `<${whatsOnPlaceUrl(place as PlaceAttributes)}|${
                   (place as PlaceAttributes).base_position
                 }>`
           }`,
@@ -242,8 +242,8 @@ export async function notifyUpgradingRating(
             isWorldEntity ? "world" : "place"
           } upgrade rating: ${
             isWorldEntity
-              ? `<${worldUrl(place)}|${place.world_name}>`
-              : `<${placeUrl(place as PlaceAttributes)}|${
+              ? `<${whatsOnWorldUrl(place)}|${place.world_name}>`
+              : `<${whatsOnPlaceUrl(place as PlaceAttributes)}|${
                   (place as PlaceAttributes).base_position
                 }>`
           }`,


### PR DESCRIPTION
Slack notifications for new/updated places, disabled places, and content rating changes now link to `decentraland.org/whats-on` instead of the legacy `/places/place/` and `/places/world/` paths.

- Added `whatsOnPlaceUrl(place)` and `whatsOnWorldUrl(entity)` helpers in `src/entities/Place/utils.ts`. Place URLs use `?position=<x.y>`; world URLs use `?world=<world_name>` (renamed from the previous `?name=`).
- `src/entities/Slack/utils.ts` switched to the new helpers in `notifyNewPlace`, `notifyUpdatePlace`, `notifyDowngradeRating`, and `notifyUpgradingRating`. The catalyst entity link is unchanged.
- `placeUrl` / `worldUrl` are intentionally left untouched so the social metadata routes (`src/entities/Social/routes.ts`) keep emitting the existing canonical / OpenGraph URLs.

## Test plan

- [x] `npm run format`
- [x] `npm run lint:fix` (no new errors)
- [x] `npm run build`
- [x] `jest src/entities/Place/utils.test.ts` (17/17, includes new cases for both helpers)
- [ ] Trigger a Slack notification in staging and confirm the link opens `decentraland.org/whats-on?position=...` / `?world=...`