### PR TITLE
fix: fall back to entity metadata for creator_address and sdk

### DIFF
--- a/src/entities/CheckScenes/task/taskRunnerSqs.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.ts
@@ -62,11 +62,25 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
     return null
   }
 
-  // Extract creator address and SDK version from scene.json
+  // Extract creator address and SDK version from scene.json. Fall back to
+  // entity metadata when the secondary blob fetch fails or returns nulls —
+  // metadata is the same scene.json already parsed by the content server, so
+  // it's the authoritative source even when the standalone fetch hiccups
+  // (CDN replication lag, transient network errors, etc).
   const sceneJsonData = await extractSceneJsonData(
     contentEntityScene,
     job.contentServerUrls![0]
   )
+  const creator =
+    sceneJsonData.creator ||
+    (contentEntityScene.metadata as { creator?: string } | undefined)
+      ?.creator ||
+    null
+  const sdk =
+    sceneJsonData.runtimeVersion ||
+    (contentEntityScene.metadata as { runtimeVersion?: string } | undefined)
+      ?.runtimeVersion ||
+    null
 
   let placesToProcess: ProcessEntitySceneResult | null = null
 
@@ -137,8 +151,8 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
 
     const options = {
       url: job.contentServerUrls![0],
-      creator: sceneJsonData.creator,
-      sdk: sceneJsonData.runtimeVersion,
+      creator,
+      sdk,
       worldId,
     }
 
@@ -214,8 +228,8 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
     )
     placesToProcess = processContentEntityScene(contentEntityScene, places, {
       url: job.contentServerUrls![0],
-      creator: sceneJsonData.creator,
-      sdk: sceneJsonData.runtimeVersion,
+      creator,
+      sdk,
     })
   }
 

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -1013,7 +1013,7 @@ describe("taskRunnerSqs integration", () => {
           title: "Fallback From Metadata",
         })
         Object.assign(scene.metadata, {
-          creator: "0xcreatorfrommetadata00000000000000000000",
+          creator: "0xcreatorfrommetadata000000000000000000000",
           runtimeVersion: "7",
         })
 
@@ -1035,7 +1035,7 @@ describe("taskRunnerSqs integration", () => {
 
         expect(response.body.data).toHaveLength(1)
         expect(response.body.data[0].creator_address).toBe(
-          "0xcreatorfrommetadata00000000000000000000"
+          "0xcreatorfrommetadata000000000000000000000"
         )
         expect(response.body.data[0].sdk).toBe("7")
       })

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -1004,4 +1004,70 @@ describe("taskRunnerSqs integration", () => {
       })
     })
   })
+
+  describe("when extractSceneJsonData fails to read scene.json", () => {
+    describe("and the entity metadata still carries creator and runtimeVersion", () => {
+      beforeEach(async () => {
+        const scene = createWorldContentEntityScene({
+          worldName: "fallback-meta.dcl.eth",
+          title: "Fallback From Metadata",
+        })
+        Object.assign(scene.metadata, {
+          creator: "0xcreatorfrommetadata00000000000000000000",
+          runtimeVersion: "7",
+        })
+
+        mockProcessEntityId.mockResolvedValueOnce(scene)
+        mockExtractSceneJsonData.mockResolvedValueOnce({
+          creator: null,
+          runtimeVersion: null,
+        })
+
+        const job = createWorldDeploymentMessage()
+        await taskRunnerSqs(job)
+      })
+
+      it("should populate creator_address and sdk from entity metadata", async () => {
+        const response = await supertest(app)
+          .get("/api/places")
+          .query({ names: "fallback-meta.dcl.eth" })
+          .expect(200)
+
+        expect(response.body.data).toHaveLength(1)
+        expect(response.body.data[0].creator_address).toBe(
+          "0xcreatorfrommetadata00000000000000000000"
+        )
+        expect(response.body.data[0].sdk).toBe("7")
+      })
+    })
+
+    describe("and the entity metadata does not carry creator or runtimeVersion", () => {
+      beforeEach(async () => {
+        const scene = createWorldContentEntityScene({
+          worldName: "no-fallback-meta.dcl.eth",
+          title: "No Fallback Available",
+        })
+
+        mockProcessEntityId.mockResolvedValueOnce(scene)
+        mockExtractSceneJsonData.mockResolvedValueOnce({
+          creator: null,
+          runtimeVersion: null,
+        })
+
+        const job = createWorldDeploymentMessage()
+        await taskRunnerSqs(job)
+      })
+
+      it("should leave creator_address and sdk null", async () => {
+        const response = await supertest(app)
+          .get("/api/places")
+          .query({ names: "no-fallback-meta.dcl.eth" })
+          .expect(200)
+
+        expect(response.body.data).toHaveLength(1)
+        expect(response.body.data[0].creator_address).toBeNull()
+        expect(response.body.data[0].sdk).toBeNull()
+      })
+    })
+  })
 })


### PR DESCRIPTION
Closes #838

## Context

Places API was returning `creator_address: null` and `sdk: null` for scenes where the content server actually had `metadata.creator` and `metadata.runtimeVersion` populated. This caused Unity Explorer's donations feature to flag legitimate scenes as phishing attempts (Sentry: 3455 events, 493 users affected since 2026-03-25).

Root cause: `extractSceneJsonData` in the SQS consumer fetches `scene.json` as a separate blob from `/contents/{hash}` after already having the parsed metadata in memory from `/entities/active`. When that secondary fetch fails (CDN replication lag, transient network errors, etc.) it silently returns `{ creator: null, runtimeVersion: null }` and the place row is written with permanent nulls.

## Changes

- `taskRunnerSqs.ts`: after calling `extractSceneJsonData`, fall back to `contentEntityScene.metadata.creator` and `contentEntityScene.metadata.runtimeVersion` before passing to `createPlaceFromContentEntityScene`. The metadata is the same scene.json already parsed by the content server, so it's the authoritative source even when the standalone blob fetch hiccups. Applies to both the world and Genesis City branches.
- `bin/backfillSceneMetadata.ts`: surgical backfill script for existing rows where `creator_address` or `sdk` is `null`. Reads `metadata.creator` / `metadata.runtimeVersion` directly from the entity (no second fetch), so it does not suffer the same silent-failure mode that produced the nulls. Defaults to dry-run; requires `--apply` to write. Supports `--places`, `--worlds`, `--limit N`, `--pointer X,Y` filters.
- `package.json`: `backfill:scene-metadata:dev` and `backfill:scene-metadata:prd` npm scripts.
- Integration tests covering the fallback path (metadata available → recovered) and the no-fallback path (metadata empty → still null, expected).

## Out of scope

This PR addresses Bug 2 from the issue (creator_address / sdk nulls) which is the direct cause of the Sentry alerts. Bug 1 (`owner` empty-string coercion in `processContentEntityScene.ts:161` for Genesis City scenes) and Bug 3 (`updated_at` spread order in `createPlaceFromContentEntityScene`) are separate concerns and will be handled in follow-up PRs.

## Test plan

- [x] Unit tests pass (`npm test`)
- [x] TypeScript build clean (`npm run build`)
- [x] ESLint clean on changed files
- [ ] Integration tests pass (`npm run test:integration`) — requires Postgres + LocalStack
- [ ] Dry-run backfill against staging shows expected delta
- [ ] Manual verification: deploy a scene with `creator` set in `scene.json`, confirm Places API returns the address
- [ ] Backfill applied to production for `129,103` (the Sentry repro case) → `/api/places?positions=129,103` returns the correct `creator_address`
