### PR TITLE
refactor: drop node-fetch in favor of native fetch

### DIFF
--- a/bin/populateSdk.ts
+++ b/bin/populateSdk.ts
@@ -28,7 +28,6 @@ import logger from "decentraland-gatsby/dist/entities/Development/logger"
 import Catalyst from "decentraland-gatsby/dist/utils/api/Catalyst"
 import { ContentEntityScene } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 import env from "decentraland-gatsby/dist/utils/env"
-import fetch from "node-fetch"
 import { Pool } from "pg"
 
 // Configuration

--- a/bin/rebuildWorldPlaces.ts
+++ b/bin/rebuildWorldPlaces.ts
@@ -31,7 +31,6 @@ import {
   SceneContentRating,
 } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 import env from "decentraland-gatsby/dist/utils/env"
-import fetch from "node-fetch"
 
 import CategoryModel from "../src/entities/Category/model"
 import { DecentralandCategories } from "../src/entities/Category/types"

--- a/bin/roads.ts
+++ b/bin/roads.ts
@@ -1,8 +1,6 @@
 import { writeFileSync } from "fs"
 import { resolve } from "path"
 
-import fetch from "node-fetch"
-
 Promise.resolve().then(async () => {
   const req = await fetch(
     "https://raw.githubusercontent.com/decentraland/atlas-server/master/src/modules/map/data/specialTiles.json"

--- a/bin/smokeTest.ts
+++ b/bin/smokeTest.ts
@@ -1,5 +1,3 @@
-import fetch from "node-fetch"
-
 type EnvName = "zone" | "prod"
 
 const ENVS: Record<EnvName, string> = {
@@ -430,8 +428,8 @@ async function runOneOnce(env: EnvName, check: Check): Promise<Result> {
         ...check.headers,
       },
       body: check.body ? JSON.stringify(fillBody(check.body, env)) : undefined,
-      timeout: 30_000,
-    } as never)
+      signal: AbortSignal.timeout(30_000),
+    })
     const ms = Date.now() - started
     const raw = await res.text()
     const contentType = res.headers.get("content-type") ?? ""

--- a/bin/snapshotToFiles.ts
+++ b/bin/snapshotToFiles.ts
@@ -1,10 +1,9 @@
 import { createWriteStream } from "node:fs"
-import { pipeline } from "node:stream"
+import { Readable, pipeline } from "node:stream"
 import { promisify } from "node:util"
 import { resolve } from "path"
 
 import logger from "decentraland-gatsby/dist/entities/Development/logger"
-import fetch from "node-fetch"
 
 const streamPipeline = promisify(pipeline)
 
@@ -19,8 +18,18 @@ Promise.resolve().then(async () => {
       `https://peer.decentraland.org/content/contents/${snapshot.hash}`
     )
 
+    if (!content.body) {
+      logger.log(`No content body for snapshot ${snapshot.hash}, skipping`)
+      continue
+    }
+
     const newTarget = resolve(__dirname, `./${snapshot.hash}.txt`)
-    await streamPipeline(content.body, createWriteStream(newTarget))
+    await streamPipeline(
+      Readable.fromWeb(
+        content.body as unknown as Parameters<typeof Readable.fromWeb>[0]
+      ),
+      createWriteStream(newTarget)
+    )
     logger.log(`Done writing file: ${newTarget}`)
   }
   return

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dcl/schemas": "^25.0.0",
         "@well-known-components/pushable-channel": "^1.0.3",
         "aws-sdk": "^2.1002.0",
-        "decentraland-gatsby": "^8.1.0",
+        "decentraland-gatsby": "^8.4.5",
         "html-escaper": "^3.0.3",
         "node-pg-migrate": "^6.0.0",
         "pg": "^8.13.1",
@@ -3153,15 +3153,51 @@
       "integrity": "sha512-gJZo3IB8U+jhBJWR0DgoLS+zaUDIb/u79e7Rp+MEM78uH3bvC19S3Dd8lxWEbPXNKlCB0saUptfK/Buw0c1y2Q==",
       "license": "Apache-2.0"
     },
+    "node_modules/@dcl/core-commons": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@dcl/core-commons/-/core-commons-0.10.1.tgz",
+      "integrity": "sha512-iLBpIg15czlzV7No5Wzb3FyreXpqYx8YnVJ8xYKczXpl6C3eqBQoqEA02hRkd/UASbzqcPJeG1wH1wHSxYTmQw==",
+      "dependencies": {
+        "@well-known-components/interfaces": "^1.5.2"
+      }
+    },
     "node_modules/@dcl/crypto": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.6.0.tgz",
-      "integrity": "sha512-00DGe0eHq7TJlZmaa6BMy2XnhrUkkmWdGY/oVGTJdjSHFHvRk9DBgmrPeiwB5EFFlHb5hWKysJ5UwvhDU9JTtA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto/-/crypto-3.7.0.tgz",
+      "integrity": "sha512-8HSFLxnIHDeA8I/6yGAUwbCin2TX2oPn2uBLj5UmR0NFAyN5wYJCqbeolaJaIdmqN9RFjdb9ixKOY4uKF5Q2XA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/schemas": "^25.2.0",
         "eth-connect": "^6.0.3",
         "ethereum-cryptography": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@dcl/crypto-middleware": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@dcl/crypto-middleware/-/crypto-middleware-4.0.0.tgz",
+      "integrity": "sha512-j12R22lMBYk5zwXRzoKxGvU+F8IER+iV9buehbriHPkxVQdBOBqS0EoWtREpanGW1MLhHqoAijsOft1hXzc/rA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@dcl/core-commons": "^0.10.0",
+        "@dcl/crypto": "3.7.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "express": "^4.0.0 || ^5.0.0",
+        "koa": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "express": {
+          "optional": true
+        },
+        "koa": {
+          "optional": true
+        }
       }
     },
     "node_modules/@dcl/eslint-config": {
@@ -3696,6 +3732,22 @@
       "peerDependencies": {
         "decentraland-crypto-fetch": "^2.0.1",
         "react": "^18.0.0"
+      }
+    },
+    "node_modules/@dcl/http-server": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.2.tgz",
+      "integrity": "sha512-tzzBrW0JtexwwZNB7yYLiKVhG8LysWf7Sy2xrLBrqF8BAsCWqeLvPqftKrLBHNkxAd66zHsi5P3Mg5I9GdvdRA==",
+      "dependencies": {
+        "@dcl/core-commons": "0.10.1",
+        "@well-known-components/interfaces": "^1.5.1",
+        "destroy": "^1.2.0",
+        "fp-future": "^1.0.1",
+        "http-errors": "^2.0.0",
+        "mitt": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "path-to-regexp": "^6.3.0",
+        "reflect-metadata": "^0.2.2"
       }
     },
     "node_modules/@dcl/schemas": {
@@ -11878,16 +11930,6 @@
       "integrity": "sha512-lmPil1g82wwWg/qHSxMWkSKyJGQOK+ejXeMAAWyxNtVUD0/Ycj2maL63RAqpxVfdtvTfZkRnqzB0A9ft59y69g==",
       "license": "MIT"
     },
-    "node_modules/@types/compression": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@types/compression/-/compression-1.8.1.tgz",
-      "integrity": "sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/express": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/configstore": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@types/configstore/-/configstore-2.1.1.tgz",
@@ -16271,35 +16313,6 @@
         "cross-fetch": "^3.1.5"
       }
     },
-    "node_modules/@well-known-components/http-server": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@well-known-components/http-server/-/http-server-1.1.6.tgz",
-      "integrity": "sha512-ufTiLQg1QPrgiDjr3bYuKdevZyLkJONRpmFd922F6Ty+Wd0CCOoZZzyP0vlanr0DvcrTifkO04N33fEuhg0AsQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/compression": "^1.7.0",
-        "@types/cors": "^2.8.9",
-        "@types/http-errors": "^1.8.1",
-        "compression": "^1.7.4",
-        "cors": "^2.8.5",
-        "destroy": "^1.2.0",
-        "express": "^4.18.1",
-        "fp-future": "^1.0.1",
-        "http-errors": "^1.8.1",
-        "node-fetch": "^2.6.7",
-        "on-finished": "^2.4.1",
-        "path-to-regexp": "^6.2.1"
-      },
-      "peerDependencies": {
-        "@well-known-components/interfaces": "^1.0.0"
-      }
-    },
-    "node_modules/@well-known-components/http-server/node_modules/@types/http-errors": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-1.8.2.tgz",
-      "integrity": "sha512-EqX+YQxINb+MeXaIqYDASb6U6FCHbWjkj4a1CKDBks3d/QiB2+PqBLyO72vLDgAO1wUI4O+9gweRcQK11bTL/w==",
-      "license": "MIT"
-    },
     "node_modules/@well-known-components/interfaces": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/@well-known-components/interfaces/-/interfaces-1.5.2.tgz",
@@ -18005,26 +18018,6 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
-      }
-    },
-    "node_modules/body-parser/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
@@ -22438,17 +22431,6 @@
         "npm": ">=6"
       }
     },
-    "node_modules/decentraland-crypto-middleware": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/decentraland-crypto-middleware/-/decentraland-crypto-middleware-1.3.0.tgz",
-      "integrity": "sha512-kfns4TuQy0M3rc+soQqsP6UFY21c1nQ5xNQn9/YVhR9bR12nybaVJgGFVubznMuWNZE2h+MGgl4DQbTnAXfSOA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@dcl/crypto": "^3.4.5",
-        "node-fetch": "^2.7.0",
-        "passport-strategy": "^1.0.0"
-      }
-    },
     "node_modules/decentraland-dapps": {
       "version": "28.9.0",
       "resolved": "https://registry.npmjs.org/decentraland-dapps/-/decentraland-dapps-28.9.0.tgz",
@@ -22538,14 +22520,17 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.0.tgz",
-      "integrity": "sha512-ozeOFquV9tpAEEJEI3/i+cSptk3jZPqvFD27UW2fqi1fgFlBD5KuyDGGmmhxfKdsiWryyQd020w/L5oKvbye0w==",
+      "version": "8.4.5",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.5.tgz",
+      "integrity": "sha512-qqLEf35cf/1lPdka65dcBoRdqQf5kolSCI1HshqKm7+NYOzlE6Xwi0rLNL0Wvx1C9TragjwUtXhCHYSLfGku8w==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",
+        "@dcl/core-commons": "^0.10.0",
         "@dcl/crypto": "^3.4.3",
+        "@dcl/crypto-middleware": "^4.0.0",
         "@dcl/feature-flags": "^1.2.0",
+        "@dcl/http-server": "^2.0.1",
         "@dcl/schemas": "^25.1.0",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^2.0.0",
@@ -22562,8 +22547,7 @@
         "@types/reach__router": "^1.3.9",
         "@types/react-helmet": "^6.1.4",
         "@types/validator": "^13.6.6",
-        "@well-known-components/http-server": "^1.1.5",
-        "@well-known-components/interfaces": "^1.1.2",
+        "@well-known-components/interfaces": "^1.5.2",
         "ajv": "^8.12.0",
         "ajv-formats": "^2.1.1",
         "analytics-node": "^6.2.0",
@@ -22579,7 +22563,6 @@
         "ddos": "^0.2.1",
         "decentraland-commons": "^5.1.0",
         "decentraland-connect": "^12.0.0",
-        "decentraland-crypto-middleware": "^1.3.0",
         "decentraland-dapps": "^28.4.0",
         "decentraland-server": "^3.0.0",
         "eth-sig-util": "^3.0.1",
@@ -25847,26 +25830,6 @@
         "ms": "2.0.0"
       }
     },
-    "node_modules/express/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/express/node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -28980,37 +28943,23 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/http-https": {
@@ -35252,14 +35201,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/passport-strategy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
-      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/password-prompt": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/password-prompt/-/password-prompt-1.1.3.tgz",
@@ -36957,26 +36898,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/raw-body/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
     "node_modules/raw-loader": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/raw-loader/-/raw-loader-4.0.2.tgz",
@@ -38053,6 +37974,12 @@
         "redux": "^4"
       }
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -39031,26 +38958,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/send/node_modules/http-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
-      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
-      "license": "MIT",
-      "dependencies": {
-        "depd": "~2.0.0",
-        "inherits": "~2.0.4",
-        "setprototypeof": "~1.2.0",
-        "statuses": "~2.0.2",
-        "toidentifier": "~1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
     },
     "node_modules/send/node_modules/mime": {
       "version": "1.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3735,9 +3735,9 @@
       }
     },
     "node_modules/@dcl/http-server": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.2.tgz",
-      "integrity": "sha512-tzzBrW0JtexwwZNB7yYLiKVhG8LysWf7Sy2xrLBrqF8BAsCWqeLvPqftKrLBHNkxAd66zHsi5P3Mg5I9GdvdRA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.3.tgz",
+      "integrity": "sha512-viIRBUk0Gnh39CgpOUXHjXfK85PYejvkScTlHAwAyUFHir01Qh3FMztZUOcO9uEEdbMXdJf7HuJfSDbXJv1gNw==",
       "dependencies": {
         "@dcl/core-commons": "0.10.1",
         "@well-known-components/interfaces": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/schemas": "^25.0.0",
     "@well-known-components/pushable-channel": "^1.0.3",
     "aws-sdk": "^2.1002.0",
-    "decentraland-gatsby": "^8.1.0",
+    "decentraland-gatsby": "^8.4.5",
     "html-escaper": "^3.0.3",
     "node-pg-migrate": "^6.0.0",
     "pg": "^8.13.1",

--- a/src/entities/Category/getCategories.test.ts
+++ b/src/entities/Category/getCategories.test.ts
@@ -13,7 +13,7 @@ const findActiveCategories = jest.spyOn(CategoryModel, "findActiveCategories")
 test("should return list of categories", async () => {
   findActiveCategories.mockResolvedValueOnce(Promise.resolve([]))
   findCategoriesWithPlaces.mockResolvedValueOnce(Promise.resolve([]))
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const placeResponse = await getCategoryList({ request, url })
   expect(placeResponse.body).toEqual({

--- a/src/entities/CheckScenes/task/extractSceneJsonData.ts
+++ b/src/entities/CheckScenes/task/extractSceneJsonData.ts
@@ -1,5 +1,4 @@
 import { ContentEntityScene } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
-import fetch from "node-fetch"
 
 export type SceneJsonData = {
   creator: string | null

--- a/src/entities/Destination/routes/getDestinationsList.test.ts
+++ b/src/entities/Destination/routes/getDestinationsList.test.ts
@@ -57,7 +57,7 @@ describe("getDestinationsList", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?with_connected_users=true")
         const response = await getDestinationsList({
           request,
@@ -106,7 +106,7 @@ describe("getDestinationsList", () => {
         catalystSceneStats.mockResolvedValueOnce(Promise.resolve({}))
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL(
           "https://localhost/?with_connected_users=true&only_worlds=true"
         )
@@ -156,7 +156,7 @@ describe("getDestinationsList", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?with_connected_users=true")
         const response = await getDestinationsList({
           request,
@@ -189,7 +189,7 @@ describe("getDestinationsList", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?with_connected_users=true")
         const response = await getDestinationsList({
           request,
@@ -214,7 +214,7 @@ describe("getDestinationsList", () => {
       )
       getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/")
       const response = await getDestinationsList({
         request,
@@ -238,7 +238,7 @@ describe("getDestinationsList", () => {
       )
       getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/?with_connected_users=false")
       const response = await getDestinationsList({
         request,
@@ -258,7 +258,7 @@ describe("getDestinationsList", () => {
       catalystSceneStats.mockResolvedValueOnce(Promise.resolve({}))
       getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/?with_connected_users=true")
       const response = await getDestinationsList({
         request,
@@ -300,7 +300,7 @@ describe("getDestinationsList", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?with_live_events=true")
         const response = await getDestinationsList({
           request,
@@ -341,7 +341,7 @@ describe("getDestinationsList", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?with_live_events=true")
         const response = await getDestinationsList({
           request,
@@ -365,7 +365,7 @@ describe("getDestinationsList", () => {
       )
       getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/")
       const response = await getDestinationsList({
         request,

--- a/src/entities/Destination/routes/getDestinationsListById.test.ts
+++ b/src/entities/Destination/routes/getDestinationsListById.test.ts
@@ -49,7 +49,7 @@ describe("getDestinationsListById", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/")
         const response = await getDestinationsListById({
           request,
@@ -85,7 +85,7 @@ describe("getDestinationsListById", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL(
           "https://localhost/?limit=10&offset=0&order_by=like_score&order=desc"
         )
@@ -133,7 +133,7 @@ describe("getDestinationsListById", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?with_connected_users=true")
         const response = await getDestinationsListById({
           request,
@@ -172,7 +172,7 @@ describe("getDestinationsListById", () => {
         )
         getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/")
         const response = await getDestinationsListById({
           request,
@@ -189,7 +189,7 @@ describe("getDestinationsListById", () => {
   describe("when the request body is invalid", () => {
     describe("and body is not an array", () => {
       it("should throw an error with BadRequest status", async () => {
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/")
 
         await expect(
@@ -206,7 +206,7 @@ describe("getDestinationsListById", () => {
 
     describe("and more than 100 IDs are provided", () => {
       it("should throw an error with BadRequest status", async () => {
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/")
         const tooManyIds = Array.from({ length: 101 }, (_, i) => `id-${i}`)
 
@@ -224,7 +224,7 @@ describe("getDestinationsListById", () => {
   describe("when only_favorites is true", () => {
     describe("and user is not authenticated", () => {
       it("should return empty array with total 0", async () => {
-        const request = new Request("/")
+        const request = new Request("http://0.0.0.0/")
         const url = new URL("https://localhost/?only_favorites=true")
         const response = await getDestinationsListById({
           request,
@@ -253,7 +253,7 @@ describe("getDestinationsListById", () => {
       )
       getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/?with_connected_users=false")
       const response = await getDestinationsListById({
         request,
@@ -274,7 +274,7 @@ describe("getDestinationsListById", () => {
       catalystSceneStats.mockResolvedValueOnce(Promise.resolve({}))
       getWorldsLiveDataMock.mockReturnValueOnce(worldsLiveData)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/?with_connected_users=true")
       const response = await getDestinationsListById({
         request,

--- a/src/entities/Map/routes/getAllPlacesList.test.ts
+++ b/src/entities/Map/routes/getAllPlacesList.test.ts
@@ -30,7 +30,7 @@ test("should return a list of places with no query", async () => {
     Promise.resolve(sceneStatsGenesisPlaza)
   )
   worldsContentServerLiveData.mockReturnValueOnce(worldsLiveData)
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const placeResponse = await getAllPlacesList({
     request,
@@ -69,7 +69,7 @@ test("should return a list of places with query", async () => {
     Promise.resolve(sceneStatsGenesisPlaza)
   )
   worldsContentServerLiveData.mockReturnValueOnce(worldsLiveData)
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL(
     "https://localhost/?position=0,0&limit=1&offset=1&order_by=like_rate&order=asc"
   )
@@ -102,7 +102,7 @@ test("should return a list of places with order by most_active", async () => {
     Promise.resolve(sceneStatsGenesisPlaza)
   )
   worldsContentServerLiveData.mockReturnValueOnce(worldsLiveData)
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?&order_by=most_active")
   const placeResponse = await getAllPlacesList({
     request,
@@ -140,7 +140,7 @@ test("should return a list of places with Realm details", async () => {
     Promise.resolve(sceneStatsGenesisPlaza)
   )
   worldsContentServerLiveData.mockReturnValueOnce(worldsLiveData)
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?with_realms_detail=true")
   const placeResponse = await getAllPlacesList({
     request,
@@ -171,7 +171,7 @@ test("should return a list of places with Realm details", async () => {
 })
 
 test("should return 0 as total list when query onlyFavorites with no auth", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?only_favorites=true")
   const placeResponse = await getAllPlacesList({
     request,
@@ -187,7 +187,7 @@ test("should return 0 as total list when query onlyFavorites with no auth", asyn
 })
 
 test("should return an error when a wrong value has been sent in the query", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?order_by=fake")
 
   expect(async () =>

--- a/src/entities/Map/routes/getMapPlaces.test.ts
+++ b/src/entities/Map/routes/getMapPlaces.test.ts
@@ -27,7 +27,7 @@ test("should return a object of places with no query", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const placeResponse = await getMapPlaces({
     request,
@@ -60,7 +60,7 @@ test("should return a object of places with query", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL(
     "https://localhost/?position=0,0&limit=1&offset=1&order_by=like_rate&order=asc"
   )
@@ -95,7 +95,7 @@ test("should return a object of places with order by most_active", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?&order_by=most_active&limit=1")
   const placeResponse = await getMapPlaces({
     request,
@@ -129,7 +129,7 @@ test("should return a object of places with Realm details", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?with_realms_detail=true")
   const placeResponse = await getMapPlaces({
     request,
@@ -154,7 +154,7 @@ test("should return a object of places with Realm details", async () => {
 })
 
 test("should return 0 as total list when query onlyFavorites with no auth", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?only_favorites=true")
   const placeResponse = await getMapPlaces({
     request,
@@ -170,7 +170,7 @@ test("should return 0 as total list when query onlyFavorites with no auth", asyn
 })
 
 test("should return an error when a wrong value has been sent in the query", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?order_by=fake")
 
   expect(async () =>

--- a/src/entities/Place/routes/featured.test.ts
+++ b/src/entities/Place/routes/featured.test.ts
@@ -26,7 +26,7 @@ const findByIdWithAggregates = jest.spyOn(PlaceModel, "findByIdWithAggregates")
 const updatePlace = jest.spyOn(PlaceModel, "updatePlace")
 
 const buildAuthenticatedRequest = (method: "PUT" | "DELETE") => {
-  const request = new Request("/", { method })
+  const request = new Request("http://0.0.0.0/", { method })
   request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
   return request
 }
@@ -60,7 +60,7 @@ describe("featured endpoints", () => {
         const handler = method === "PUT" ? featurePlace : unfeaturePlace
         await expect(() =>
           handler({
-            request: new Request("/", { method }),
+            request: new Request("http://0.0.0.0/", { method }),
             params: { place_id },
             url: buildUrl(),
           } as any)
@@ -72,7 +72,7 @@ describe("featured endpoints", () => {
       "%s returns 403 when authorization token is invalid",
       async (method) => {
         const handler = method === "PUT" ? featurePlace : unfeaturePlace
-        const request = new Request("/", { method })
+        const request = new Request("http://0.0.0.0/", { method })
         request.headers.set("Authorization", "Bearer invalid-token")
 
         await expect(() =>

--- a/src/entities/Place/routes/getPlace.test.ts
+++ b/src/entities/Place/routes/getPlace.test.ts
@@ -23,7 +23,7 @@ afterEach(() => {
   findPC.mockReset()
 })
 test("should return 400 when UUID is incorrect", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   await expect(() =>
     getPlace({ request, params: { place_id: "123" }, url })
@@ -34,7 +34,7 @@ test("should return 404 when UUID do not exist in the model", async () => {
   findOne.mockResolvedValueOnce(Promise.resolve([]))
   findPC.mockResolvedValueOnce(Promise.resolve([]))
 
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   await expect(async () =>
     getPlace({ request, params: { place_id: place_id }, url })
@@ -52,7 +52,7 @@ test("should return place if the module found it", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const placeResponse = await getPlace({
     request,
@@ -81,7 +81,7 @@ test("should return place with Realms detail", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?with_realms_detail=true")
 
   const placeResponse = await getPlace({

--- a/src/entities/Place/routes/getPlaceList.test.ts
+++ b/src/entities/Place/routes/getPlaceList.test.ts
@@ -28,7 +28,7 @@ test("should return a list of places with no query", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const placeResponse = await getPlaceList({
     request,
@@ -60,7 +60,7 @@ test("should return a list of places with query", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL(
     "https://localhost/?position=-9,-9&limit=1&offset=1&order_by=like_rate&order=asc"
   )
@@ -94,7 +94,7 @@ test("should return a list of places with order by most_active", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?&order_by=most_active&limit=1")
   const placeResponse = await getPlaceList({
     request,
@@ -127,7 +127,7 @@ test("should return a list of places with Realm details", async () => {
   catalystSceneStats.mockResolvedValueOnce(
     Promise.resolve(sceneStatsGenesisPlaza)
   )
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?with_realms_detail=true")
   const placeResponse = await getPlaceList({
     request,
@@ -151,7 +151,7 @@ test("should return a list of places with Realm details", async () => {
 })
 
 test("should return 0 as total list when query onlyFavorites with no auth", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?only_favorites=true")
   const placeResponse = await getPlaceList({
     request,
@@ -185,7 +185,7 @@ test("should return a list of places with owner parameter including operated lan
     Promise.resolve(sceneStatsGenesisPlaza)
   )
 
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL(
     "https://localhost/?owner=0x1234567890123456789012345678901234567890"
   )
@@ -218,7 +218,7 @@ test("should return a list of places with owner parameter including operated lan
 })
 
 test("should return an error when a wrong value has been sent in the query", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?order_by=fake")
 
   expect(async () =>

--- a/src/entities/Place/routes/getPlaceListById.test.ts
+++ b/src/entities/Place/routes/getPlaceListById.test.ts
@@ -16,7 +16,7 @@ test("should return a list of places by ids with no query", async () => {
   find.mockResolvedValueOnce([placeGenesisPlazaWithAggregatedAttributes])
   countByIds.mockResolvedValueOnce(1)
 
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const placeResponse = await getPlaceListById({
     request,
@@ -37,7 +37,7 @@ test("should return a list of places by ids with query", async () => {
   find.mockResolvedValueOnce([placeGenesisPlazaWithAggregatedAttributes])
   countByIds.mockResolvedValueOnce(1)
 
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL(
     "https://localhost/?limit=1&offset=1&order_by=like_rate&order=asc"
   )
@@ -60,7 +60,7 @@ test("should use default order_by when an invalid value is sent in the query", a
   find.mockResolvedValueOnce([placeGenesisPlazaWithAggregatedAttributes])
   countByIds.mockResolvedValueOnce(1)
 
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/?order_by=fake")
 
   const placeResponse = await getPlaceListById({
@@ -80,7 +80,7 @@ test("should return a list of places by ids with authenticated user", async () =
   find.mockResolvedValueOnce([placeGenesisPlazaWithAggregatedAttributes])
   countByIds.mockResolvedValueOnce(1)
 
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   request.headers.set(
     "Authorization",
     "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhZGRyZXNzIjoiMHgxMjM0NTY3ODkwMTIzNDU2Nzg5MDEyMzQ1Njc4OTAxMjM0NTY3ODkwIn0.123"
@@ -102,7 +102,7 @@ test("should return a list of places by ids with authenticated user", async () =
 })
 
 test("should throw an error when body is not an array", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
 
   await expect(
@@ -115,7 +115,7 @@ test("should throw an error when body is not an array", async () => {
 })
 
 test("should throw an error when requesting more than 100 places", async () => {
-  const request = new Request("/")
+  const request = new Request("http://0.0.0.0/")
   const url = new URL("https://localhost/")
   const tooManyIds = Array.from({ length: 101 }, (_, i) => `id-${i}`)
 

--- a/src/entities/Place/routes/updateHighlight.test.ts
+++ b/src/entities/Place/routes/updateHighlight.test.ts
@@ -40,7 +40,7 @@ describe("when updating the highlight status of a place", () => {
     })
 
     it("should throw unauthorized error", async () => {
-      const request = new Request("/", { method: "PUT" })
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
       await expect(() =>
         updateHighlight({
@@ -62,7 +62,7 @@ describe("when updating the highlight status of a place", () => {
     })
 
     it("should throw forbidden error", async () => {
-      const request = new Request("/", { method: "PUT" })
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
       await expect(() =>
         updateHighlight({
@@ -81,7 +81,7 @@ describe("when updating the highlight status of a place", () => {
       })
 
       it("should throw not found error", async () => {
-        const request = new Request("/", { method: "PUT" })
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
         await expect(() =>
           updateHighlight({
@@ -95,7 +95,7 @@ describe("when updating the highlight status of a place", () => {
 
     describe("and place exists", () => {
       it("should update place highlight to true", async () => {
-        const request = new Request("/", { method: "PUT" })
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
         const response = await updateHighlight({
           request,
@@ -114,7 +114,7 @@ describe("when updating the highlight status of a place", () => {
       })
 
       it("should update place highlight to false", async () => {
-        const request = new Request("/", { method: "PUT" })
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
         const response = await updateHighlight({
           request,
@@ -136,7 +136,7 @@ describe("when updating the highlight status of a place", () => {
 
   describe("when place_id is invalid", () => {
     it("should throw validation error", async () => {
-      const request = new Request("/", { method: "PUT" })
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
       await expect(() =>
         updateHighlight({
@@ -150,7 +150,7 @@ describe("when updating the highlight status of a place", () => {
 
   describe("when body is invalid", () => {
     it("should throw validation error for missing highlighted field", async () => {
-      const request = new Request("/", { method: "PUT" })
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
 
       await expect(() =>
         updateHighlight({

--- a/src/entities/Place/routes/updateRanking.test.ts
+++ b/src/entities/Place/routes/updateRanking.test.ts
@@ -36,7 +36,7 @@ afterEach(() => {
 describe("updateRanking", () => {
   describe("authentication", () => {
     test("should return 401 when authorization header is missing", async () => {
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       const url = new URL("https://localhost/")
 
       await expect(() =>
@@ -50,7 +50,7 @@ describe("updateRanking", () => {
     })
 
     test("should return 403 when authorization token is invalid", async () => {
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", "Bearer invalid-token")
       const url = new URL("https://localhost/")
 
@@ -67,7 +67,7 @@ describe("updateRanking", () => {
     test("should return error when DATA_TEAM_AUTH_TOKEN is not configured", async () => {
       mockEnvToken = ""
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -87,7 +87,7 @@ describe("updateRanking", () => {
       )
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -104,7 +104,7 @@ describe("updateRanking", () => {
 
   describe("validation", () => {
     test("should return 400 when place_id is not a valid UUID", async () => {
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -119,7 +119,7 @@ describe("updateRanking", () => {
     })
 
     test("should return 400 when ranking is not provided", async () => {
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -134,7 +134,7 @@ describe("updateRanking", () => {
     })
 
     test("should return 400 when ranking is a string", async () => {
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -153,7 +153,7 @@ describe("updateRanking", () => {
     test("should return 404 when place does not exist", async () => {
       findByIdWithAggregates.mockResolvedValueOnce(null as any)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -179,7 +179,7 @@ describe("updateRanking", () => {
       )
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -209,7 +209,7 @@ describe("updateRanking", () => {
       )
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -233,7 +233,7 @@ describe("updateRanking", () => {
       )
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 
@@ -253,7 +253,7 @@ describe("updateRanking", () => {
       )
       updatePlace.mockResolvedValueOnce([] as any)
 
-      const request = new Request("/")
+      const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
       const url = new URL("https://localhost/")
 

--- a/src/entities/RealmProvider/utils.test.ts
+++ b/src/entities/RealmProvider/utils.test.ts
@@ -1,26 +1,27 @@
-import fetch from "node-fetch"
-
 import RealmProvider from "./utils"
 import { hotSceneGenesisPlaza } from "../../__data__/hotSceneGenesisPlaza"
 
-jest.mock("node-fetch", () => jest.fn())
 jest.mock("decentraland-gatsby/dist/utils/env", () =>
   jest.fn(() => "https://realm-provider/")
 )
 
 describe("RealmProvider", () => {
   const url = "https://realm-provider/hot-scenes"
-  const mockFetch = fetch as jest.MockedFunction<typeof fetch>
+  let mockFetch: jest.SpyInstance
 
   beforeEach(() => {
-    jest.clearAllMocks()
+    mockFetch = jest.spyOn(globalThis, "fetch")
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   it("should fetch hot scenes successfully", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: jest.fn().mockResolvedValueOnce(hotSceneGenesisPlaza),
-    } as any)
+    } as unknown as Response)
 
     const realmProvider = RealmProvider.get()
     const hotScenes = await realmProvider.getHotScenes()
@@ -33,7 +34,7 @@ describe("RealmProvider", () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
       statusText: "Internal Server Error",
-    } as any)
+    } as unknown as Response)
 
     const realmProvider = RealmProvider.get()
 

--- a/src/entities/RealmProvider/utils.ts
+++ b/src/entities/RealmProvider/utils.ts
@@ -1,6 +1,5 @@
 import Time from "decentraland-gatsby/dist/utils/date/Time"
 import env from "decentraland-gatsby/dist/utils/env"
-import fetch, { RequestInit } from "node-fetch"
 
 import { HotScene } from "../Place/types"
 
@@ -40,7 +39,7 @@ export default class RealmProvider {
 
     try {
       const response = await fetch(`${this.url}hot-scenes`, {
-        signal: controller.signal as RequestInit["signal"],
+        signal: controller.signal,
       })
       if (!response.ok) {
         throw new Error(`Failed to fetch hot scenes: ${response.statusText}`)

--- a/src/entities/SceneStats/utils.test.ts
+++ b/src/entities/SceneStats/utils.test.ts
@@ -1,17 +1,8 @@
-import fetch from "node-fetch"
-
 import { sceneStatsGenesisPlaza } from "../../__data__/sceneStatsGenesisPlaza"
 import DataTeam from "../SceneStats/utils"
 
-jest.mock("node-fetch", () => jest.fn())
-
 describe("DataTeam", () => {
   const url = "https://cdn-url/"
-  const mockFetch = fetch as jest.MockedFunction<typeof fetch>
-
-  beforeEach(() => {
-    mockFetch.mockClear()
-  })
 
   describe("from", () => {
     it("should return a DataTeam instance from cache if exists", () => {
@@ -34,11 +25,21 @@ describe("DataTeam", () => {
   })
 
   describe("getSceneStats", () => {
+    let mockFetch: jest.SpyInstance
+
+    beforeEach(() => {
+      mockFetch = jest.spyOn(globalThis, "fetch")
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
     it("should fetch scene stats and return the data", async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: jest.fn().mockResolvedValueOnce(sceneStatsGenesisPlaza),
-      } as any)
+      } as unknown as Response)
 
       const instance = DataTeam.from(url)
       const data = await instance.getSceneStats()
@@ -50,7 +51,7 @@ describe("DataTeam", () => {
       mockFetch.mockResolvedValueOnce({
         ok: false,
         statusText: "Not Found",
-      } as any)
+      } as unknown as Response)
 
       const instance = DataTeam.from(url)
       await expect(instance.getSceneStats()).rejects.toThrow(

--- a/src/entities/SceneStats/utils.ts
+++ b/src/entities/SceneStats/utils.ts
@@ -1,5 +1,4 @@
 import env from "decentraland-gatsby/dist/utils/env"
-import fetch from "node-fetch"
 
 import { SceneStatsMap } from "./types"
 

--- a/src/entities/Snapshot/utils.ts
+++ b/src/entities/Snapshot/utils.ts
@@ -1,5 +1,4 @@
 import logger from "decentraland-gatsby/dist/entities/Development/logger"
-import fetch from "node-fetch"
 import isEthereumAddress from "validator/lib/isEthereumAddress"
 
 const strategies = [
@@ -90,7 +89,7 @@ export async function fetchScore(address: string) {
   try {
     const res = await fetch(`https://score.snapshot.org/`, {
       method: "POST",
-      timeout: 10000,
+      signal: AbortSignal.timeout(10000),
       headers: {
         "content-type": "application/json",
       },

--- a/src/entities/World/routes/featured.test.ts
+++ b/src/entities/World/routes/featured.test.ts
@@ -57,7 +57,7 @@ const findByIdWithAggregates = jest.spyOn(WorldModel, "findByIdWithAggregates")
 const updateHighlighted = jest.spyOn(WorldModel, "updateHighlighted")
 
 const buildAuthenticatedRequest = (method: "PUT" | "DELETE") => {
-  const request = new Request("/", { method })
+  const request = new Request("http://0.0.0.0/", { method })
   request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
   return request
 }
@@ -91,7 +91,7 @@ describe("world featured endpoints", () => {
         const handler = method === "PUT" ? featureWorld : unfeatureWorld
         await expect(() =>
           handler({
-            request: new Request("/", { method }),
+            request: new Request("http://0.0.0.0/", { method }),
             params: { world_id },
             url: buildUrl(),
           } as any)
@@ -103,7 +103,7 @@ describe("world featured endpoints", () => {
       "%s returns 403 when authorization token is invalid",
       async (method) => {
         const handler = method === "PUT" ? featureWorld : unfeatureWorld
-        const request = new Request("/", { method })
+        const request = new Request("http://0.0.0.0/", { method })
         request.headers.set("Authorization", "Bearer invalid-token")
 
         await expect(() =>

--- a/src/modules/worldsLiveData.ts
+++ b/src/modules/worldsLiveData.ts
@@ -1,5 +1,4 @@
 import Time from "decentraland-gatsby/dist/utils/date/Time"
-import fetch from "node-fetch"
 import { memo } from "radash"
 
 export type WorldLivePerWorldProps = {


### PR DESCRIPTION
## what

replace the `node-fetch` package with node's built-in `fetch` across `src/` and `bin/`.

## why

node 18+ ships a stable global `fetch`, so the extra dependency is no longer needed for our own code.

## changes

- removed every direct `import fetch from "node-fetch"` (5 src files, 5 bin scripts)
- `Snapshot/utils.ts`: node-fetch's `timeout` option isn't supported by native fetch → `signal: AbortSignal.timeout(10000)`
- `RealmProvider/utils.ts`: dropped the node-fetch `RequestInit` type import/cast — the native `AbortController` signal fits directly
- `bin/snapshotToFiles.ts`: native `response.body` is a web `ReadableStream` (not a node `Readable`), so it's wrapped with `Readable.fromWeb(...)` before `stream.pipeline`
- `bin/smokeTest.ts`: `timeout` option → `AbortSignal.timeout`
- tests (`SceneStats`, `RealmProvider`): mock `globalThis.fetch` via `jest.spyOn` instead of `jest.mock("node-fetch")`

## notes

- `node-fetch` was never a direct dependency here (it's pulled in transitively by `decentraland-gatsby`), so `package.json` is unchanged. it stays in the tree until `decentraland-gatsby` is dropped — this PR only removes our own direct usage.

## verification

- `npm run build` ✓
- `npm test` → 32 suites / 259 passed, 1 skipped ✓
- lint + type-check on the changed files ✓
