### PR TITLE
fix: order most-active destinations by realtime user count

### DIFF
--- a/src/entities/Destination/model.ts
+++ b/src/entities/Destination/model.ts
@@ -1,5 +1,6 @@
 import {
   SQL,
+  SQLStatement,
   conditional,
   limit,
   offset,
@@ -47,8 +48,36 @@ const WORLDS_DESTINATION_SELECT = SQL`
   lp.contact_email, lp.creator_address, lp.sdk, w.ranking,
   0 as user_visits`
 
-/** Cast to int so UNION type matches places (is_most_active_place is (x)::int there). */
-const WORLDS_IS_MOST_ACTIVE_PLACE = SQL`, 0::int as is_most_active_place`
+/** Fallback when there is no realtime data: every destination ranks as 0 active users. */
+const ZERO_LIVE_USER_COUNT = SQL`, 0::int as live_user_count`
+
+/**
+ * Build a `live_user_count` SELECT column for places from the realtime hot-scenes counts,
+ * matching on `base_position`. Values are bound as query params (no string interpolation).
+ * Returns a 0 column when there is no realtime data so the UNION stays column-aligned.
+ */
+function placesLiveUserCountSelect(
+  counts: { base_position: string; count: number }[] | undefined
+): SQLStatement {
+  if (!counts || counts.length === 0) return ZERO_LIVE_USER_COUNT
+  let cases = SQL``
+  for (const c of counts) cases = SQL`${cases} WHEN ${c.base_position} THEN ${c.count}`
+  return SQL`, COALESCE(CASE p.base_position${cases} ELSE 0 END, 0)::int as live_user_count`
+}
+
+/**
+ * Build a `live_user_count` SELECT column for worlds from the realtime world live-data counts,
+ * matching on `world_name` (case-insensitive). Mirrors {@link placesLiveUserCountSelect}.
+ */
+function worldsLiveUserCountSelect(
+  counts: { world_name: string; count: number }[] | undefined
+): SQLStatement {
+  if (!counts || counts.length === 0) return ZERO_LIVE_USER_COUNT
+  let cases = SQL``
+  for (const c of counts)
+    cases = SQL`${cases} WHEN ${c.world_name.toLowerCase()} THEN ${c.count}`
+  return SQL`, COALESCE(CASE LOWER(w.world_name)${cases} ELSE 0 END, 0)::int as live_user_count`
+}
 
 export default class DestinationModel {
   /**
@@ -74,14 +103,25 @@ export default class DestinationModel {
 
     const orderDirection = oneOf(options.order, ["asc", "desc"]) ?? "desc"
 
-    const filterMostActivePlaces =
-      options.order_by === PlaceListOrderBy.MOST_ACTIVE &&
-      !!options.hotScenesPositions &&
-      options.hotScenesPositions.length > 0
+    const filterMostActive = options.order_by === PlaceListOrderBy.MOST_ACTIVE
+
+    // When ordering by MOST_ACTIVE, expose a `live_user_count` column built from the realtime
+    // counts so the query can ORDER BY the actual connected users — places (hot scenes) and
+    // worlds (world live data) alike, instead of a hot-scenes-only boolean. See #7344.
+    const placesSelect = filterMostActive
+      ? SQL`${PLACES_DESTINATION_SELECT}${placesLiveUserCountSelect(
+          options.placeUserCounts
+        )}`
+      : PLACES_DESTINATION_SELECT
+    const worldsSelect = filterMostActive
+      ? SQL`${WORLDS_DESTINATION_SELECT}${worldsLiveUserCountSelect(
+          options.worldUserCounts
+        )}`
+      : WORLDS_DESTINATION_SELECT
 
     if (options.only_places) {
       const placesQuery = PlaceModel.buildSubQuery(options, {
-        selectColumns: PLACES_DESTINATION_SELECT,
+        selectColumns: placesSelect,
         worldFilter: "always",
       })
       const sql = SQL`
@@ -89,10 +129,7 @@ export default class DestinationModel {
         ORDER BY
           p.highlighted DESC,
           p.ranking DESC NULLS LAST,
-          ${conditional(
-            filterMostActivePlaces,
-            SQL`is_most_active_place DESC, `
-          )}
+          ${conditional(filterMostActive, SQL`live_user_count DESC, `)}
           ${conditional(!!options.search, SQL`rank DESC, `)}
           ${SQL.raw(
             `p.${orderBy} ${orderDirection.toUpperCase()} NULLS LAST, p."deployed_at" DESC`
@@ -121,13 +158,14 @@ export default class DestinationModel {
           sdk: options.sdk,
           creator_address: options.creator_address,
         },
-        { selectColumns: WORLDS_DESTINATION_SELECT }
+        { selectColumns: worldsSelect }
       )
       const sql = SQL`
         ${worldsQuery}
         ORDER BY
           w.highlighted DESC,
           w.ranking DESC NULLS LAST,
+          ${conditional(filterMostActive, SQL`live_user_count DESC, `)}
           ${conditional(!!options.search, SQL`rank DESC, `)}
           ${SQL.raw(
             `w.${orderBy} ${orderDirection.toUpperCase()} NULLS LAST, w.updated_at DESC`
@@ -141,9 +179,9 @@ export default class DestinationModel {
       )
     }
 
-    // UNION ALL strategy (both subqueries must have the same columns; places add is_most_active_place when order_by=most_active)
+    // UNION ALL strategy (both subqueries must have the same columns; both add live_user_count when order_by=most_active)
     const placesQuery = PlaceModel.buildSubQuery(options, {
-      selectColumns: PLACES_DESTINATION_SELECT,
+      selectColumns: placesSelect,
       worldFilter: "always",
     })
     const worldsQuery = WorldModel.buildSubQuery(
@@ -161,10 +199,7 @@ export default class DestinationModel {
         creator_address: options.creator_address,
       },
       {
-        selectColumns: WORLDS_DESTINATION_SELECT,
-        extraSelectAfterUserColumns: filterMostActivePlaces
-          ? WORLDS_IS_MOST_ACTIVE_PLACE
-          : undefined,
+        selectColumns: worldsSelect,
       }
     )
 
@@ -177,10 +212,7 @@ export default class DestinationModel {
       ORDER BY
         sub.highlighted DESC,
         sub.ranking DESC NULLS LAST,
-        ${conditional(
-          filterMostActivePlaces,
-          SQL`sub.is_most_active_place DESC, `
-        )}
+        ${conditional(filterMostActive, SQL`sub.live_user_count DESC, `)}
         ${conditional(!!options.search, SQL`sub.rank DESC, `)}
         ${SQL.raw(
           `sub.${orderBy} ${orderDirection.toUpperCase()} NULLS LAST, sub.updated_at DESC`

--- a/src/entities/Destination/model.ts
+++ b/src/entities/Destination/model.ts
@@ -61,7 +61,8 @@ function placesLiveUserCountSelect(
 ): SQLStatement {
   if (!counts || counts.length === 0) return ZERO_LIVE_USER_COUNT
   let cases = SQL``
-  for (const c of counts) cases = SQL`${cases} WHEN ${c.base_position} THEN ${c.count}`
+  for (const c of counts)
+    cases = SQL`${cases} WHEN ${c.base_position} THEN ${c.count}`
   return SQL`, COALESCE(CASE p.base_position${cases} ELSE 0 END, 0)::int as live_user_count`
 }
 

--- a/src/entities/Destination/routes/getDestinationsList.ts
+++ b/src/entities/Destination/routes/getDestinationsList.ts
@@ -110,19 +110,30 @@ export const getDestinationsList = Router.memo(
       }
     }
 
-    // Get positions from hot scenes for MOST_ACTIVE ordering
-    const hotScenesPositions =
-      query.order_by === PlaceListOrderBy.MOST_ACTIVE
-        ? hotScenes
-            .map((scene) => scene.parcels.map((parcel) => parcel.join(",")))
-            .flat()
-        : []
+    // Realtime connected-user counts injected into the query so MOST_ACTIVE orders by the actual
+    // number of users — across places (hot scenes) AND worlds (world live data). See issue #7344.
+    const isMostActive = query.order_by === PlaceListOrderBy.MOST_ACTIVE
 
-    // Add operatedPositions and hotScenesPositions to options for enhanced query
+    const placeUserCounts = isMostActive
+      ? hotScenes.map((scene) => ({
+          base_position: scene.baseCoords.join(","),
+          count: scene.usersTotalCount,
+        }))
+      : []
+
+    const worldUserCounts = isMostActive
+      ? (getWorldsLiveData().perWorld ?? []).map((world) => ({
+          world_name: world.worldName,
+          count: world.users,
+        }))
+      : []
+
+    // Add operatedPositions and realtime counts to options for the enhanced query
     const enhancedOptions = {
       ...options,
       operatedPositions,
-      hotScenesPositions,
+      placeUserCounts,
+      worldUserCounts,
     }
 
     const [data, total, sceneStats] = await Promise.all([

--- a/src/entities/Destination/routes/getDestinationsList.ts
+++ b/src/entities/Destination/routes/getDestinationsList.ts
@@ -111,12 +111,15 @@ export const getDestinationsList = Router.memo(
       }
     }
 
+    // Fetched once and reused for both the realtime-count injection and the response enrichment.
+    const worldsLiveData = getWorldsLiveData()
+
     // Realtime connected-user counts injected into the query so MOST_ACTIVE orders by the actual
     // number of users — across places (hot scenes) AND worlds (world live data). See issue #7344.
     const { placeUserCounts, worldUserCounts } = buildRealtimeUserCounts(
       query.order_by,
       hotScenes,
-      getWorldsLiveData()
+      worldsLiveData
     )
 
     // Add operatedPositions and realtime counts to options for the enhanced query
@@ -132,7 +135,6 @@ export const getDestinationsList = Router.memo(
       DestinationModel.count(enhancedOptions),
       getSceneStats(),
     ])
-    const worldsLiveData = getWorldsLiveData()
 
     // Fetch connected users if requested
     const withConnectedUsers = !!bool(query.with_connected_users)

--- a/src/entities/Destination/routes/getDestinationsList.ts
+++ b/src/entities/Destination/routes/getDestinationsList.ts
@@ -22,6 +22,7 @@ import {
 import {
   ConnectedUsersMap,
   LiveEventsMap,
+  buildRealtimeUserCounts,
   destinationsWithAggregates,
   fetchConnectedUsersForDestinations,
   fetchLiveEventsForDestinations,
@@ -112,21 +113,11 @@ export const getDestinationsList = Router.memo(
 
     // Realtime connected-user counts injected into the query so MOST_ACTIVE orders by the actual
     // number of users — across places (hot scenes) AND worlds (world live data). See issue #7344.
-    const isMostActive = query.order_by === PlaceListOrderBy.MOST_ACTIVE
-
-    const placeUserCounts = isMostActive
-      ? hotScenes.map((scene) => ({
-          base_position: scene.baseCoords.join(","),
-          count: scene.usersTotalCount,
-        }))
-      : []
-
-    const worldUserCounts = isMostActive
-      ? (getWorldsLiveData().perWorld ?? []).map((world) => ({
-          world_name: world.worldName,
-          count: world.users,
-        }))
-      : []
+    const { placeUserCounts, worldUserCounts } = buildRealtimeUserCounts(
+      query.order_by,
+      hotScenes,
+      getWorldsLiveData()
+    )
 
     // Add operatedPositions and realtime counts to options for the enhanced query
     const enhancedOptions = {

--- a/src/entities/Destination/routes/getDestinationsListById.ts
+++ b/src/entities/Destination/routes/getDestinationsListById.ts
@@ -24,6 +24,7 @@ import {
 import {
   ConnectedUsersMap,
   LiveEventsMap,
+  buildRealtimeUserCounts,
   destinationsWithAggregates,
   fetchConnectedUsersForDestinations,
   fetchLiveEventsForDestinations,
@@ -131,21 +132,11 @@ export const getDestinationsListById = Router.memo(
 
     // Realtime connected-user counts injected into the query so MOST_ACTIVE orders by the actual
     // number of users — across places (hot scenes) AND worlds (world live data). See issue #7344.
-    const isMostActive = query.order_by === PlaceListOrderBy.MOST_ACTIVE
-
-    const placeUserCounts = isMostActive
-      ? hotScenes.map((scene) => ({
-          base_position: scene.baseCoords.join(","),
-          count: scene.usersTotalCount,
-        }))
-      : []
-
-    const worldUserCounts = isMostActive
-      ? (getWorldsLiveData().perWorld ?? []).map((world) => ({
-          world_name: world.worldName,
-          count: world.users,
-        }))
-      : []
+    const { placeUserCounts, worldUserCounts } = buildRealtimeUserCounts(
+      query.order_by,
+      hotScenes,
+      getWorldsLiveData()
+    )
 
     // Add operatedPositions and realtime counts to options for the enhanced query
     const enhancedOptions = {

--- a/src/entities/Destination/routes/getDestinationsListById.ts
+++ b/src/entities/Destination/routes/getDestinationsListById.ts
@@ -129,19 +129,30 @@ export const getDestinationsListById = Router.memo(
       }
     }
 
-    // Get positions from hot scenes for MOST_ACTIVE ordering
-    const hotScenesPositions =
-      query.order_by === PlaceListOrderBy.MOST_ACTIVE
-        ? hotScenes
-            .map((scene) => scene.parcels.map((parcel) => parcel.join(",")))
-            .flat()
-        : []
+    // Realtime connected-user counts injected into the query so MOST_ACTIVE orders by the actual
+    // number of users — across places (hot scenes) AND worlds (world live data). See issue #7344.
+    const isMostActive = query.order_by === PlaceListOrderBy.MOST_ACTIVE
 
-    // Add operatedPositions and hotScenesPositions to options for enhanced query
+    const placeUserCounts = isMostActive
+      ? hotScenes.map((scene) => ({
+          base_position: scene.baseCoords.join(","),
+          count: scene.usersTotalCount,
+        }))
+      : []
+
+    const worldUserCounts = isMostActive
+      ? (getWorldsLiveData().perWorld ?? []).map((world) => ({
+          world_name: world.worldName,
+          count: world.users,
+        }))
+      : []
+
+    // Add operatedPositions and realtime counts to options for the enhanced query
     const enhancedOptions = {
       ...options,
       operatedPositions,
-      hotScenesPositions,
+      placeUserCounts,
+      worldUserCounts,
     }
 
     const [data, total, sceneStats] = await Promise.all([

--- a/src/entities/Destination/routes/getDestinationsListById.ts
+++ b/src/entities/Destination/routes/getDestinationsListById.ts
@@ -130,12 +130,15 @@ export const getDestinationsListById = Router.memo(
       }
     }
 
+    // Fetched once and reused for both the realtime-count injection and the response enrichment.
+    const worldsLiveData = getWorldsLiveData()
+
     // Realtime connected-user counts injected into the query so MOST_ACTIVE orders by the actual
     // number of users — across places (hot scenes) AND worlds (world live data). See issue #7344.
     const { placeUserCounts, worldUserCounts } = buildRealtimeUserCounts(
       query.order_by,
       hotScenes,
-      getWorldsLiveData()
+      worldsLiveData
     )
 
     // Add operatedPositions and realtime counts to options for the enhanced query
@@ -151,7 +154,6 @@ export const getDestinationsListById = Router.memo(
       DestinationModel.count(enhancedOptions),
       getSceneStats(),
     ])
-    const worldsLiveData = getWorldsLiveData()
 
     // Fetch connected users if requested
     const withConnectedUsers = !!bool(query.with_connected_users)

--- a/src/entities/Destination/types.ts
+++ b/src/entities/Destination/types.ts
@@ -84,6 +84,13 @@ export type FindDestinationsWithAggregatesOptions = DestinationsListOptions & {
   operatedPositions?: string[]
   hotScenesPositions?: string[]
   ids?: string[]
+  /**
+   * Realtime connected-user counts injected into the query for MOST_ACTIVE ordering.
+   * Places are keyed by `base_position` (from hot scenes), worlds by `world_name`
+   * (from world live data). See issue #7344.
+   */
+  placeUserCounts?: { base_position: string; count: number }[]
+  worldUserCounts?: { world_name: string; count: number }[]
 }
 
 /**

--- a/src/entities/Destination/types.ts
+++ b/src/entities/Destination/types.ts
@@ -82,7 +82,6 @@ export type DestinationsListOptions = CommonFilterFields & {
 export type FindDestinationsWithAggregatesOptions = DestinationsListOptions & {
   user?: string
   operatedPositions?: string[]
-  hotScenesPositions?: string[]
   ids?: string[]
   /**
    * Realtime connected-user counts injected into the query for MOST_ACTIVE ordering.

--- a/src/entities/Destination/utils.ts
+++ b/src/entities/Destination/utils.ts
@@ -2,11 +2,42 @@ import { AggregateDestinationAttributes } from "./types"
 import CommsGatekeeper from "../../api/CommsGatekeeper"
 import { SceneStats, SceneStatsMap } from "../../api/DataTeam"
 import Events from "../../api/Events"
-import { HotScene } from "../Place/types"
+import { HotScene, PlaceListOrderBy } from "../Place/types"
 import { WorldLiveDataProps } from "../World/types"
 
 export type ConnectedUsersMap = Map<string, string[]>
 export type LiveEventsMap = Map<string, boolean>
+
+export type RealtimeUserCounts = {
+  placeUserCounts: { base_position: string; count: number }[]
+  worldUserCounts: { world_name: string; count: number }[]
+}
+
+/**
+ * Build the realtime connected-user counts injected into the destinations query for MOST_ACTIVE
+ * ordering: places keyed by `base_position` (from hot scenes) and worlds by `world_name` (from
+ * world live data). Returns empty arrays unless ordering by most_active. See issue #7344.
+ */
+export function buildRealtimeUserCounts(
+  orderBy: string,
+  hotScenes: HotScene[],
+  worldsLiveData: WorldLiveDataProps
+): RealtimeUserCounts {
+  if (orderBy !== PlaceListOrderBy.MOST_ACTIVE) {
+    return { placeUserCounts: [], worldUserCounts: [] }
+  }
+
+  return {
+    placeUserCounts: hotScenes.map((scene) => ({
+      base_position: scene.baseCoords.join(","),
+      count: scene.usersTotalCount,
+    })),
+    worldUserCounts: (worldsLiveData.perWorld ?? []).map((world) => ({
+      world_name: world.worldName,
+      count: world.users,
+    })),
+  }
+}
 
 /**
  * Fetches connected users for a list of destinations from comms-gatekeeper.

--- a/test/integration/getDestinationsList.test.ts
+++ b/test/integration/getDestinationsList.test.ts
@@ -1281,7 +1281,7 @@ describe("when fetching destinations via GET /destinations", () => {
       })
 
       describe("and there are multiple most_active places", () => {
-        it("should order them by like_score descending", async () => {
+        it("should order them by live connected users descending", async () => {
           const response = await supertest(app)
             .get("/api/destinations")
             .query({ order_by: "most_active", offset: 0, limit: 100 })
@@ -1304,9 +1304,11 @@ describe("when fetching destinations via GET /destinations", () => {
           const indexGarden = mostActivePlaces.findIndex(
             (d) => d.base_position === "20,20"
           )
-          expect(indexMuseum).toBeLessThan(indexGarden)
-          expect(mostActivePlaces[indexMuseum].like_score).toBe(30)
-          expect(mostActivePlaces[indexGarden].like_score).toBe(10)
+          // Garden (20,20) has 15 live users vs Museum (10,10) with 5, so it ranks first
+          // even though Museum has the higher like_score (30 vs 10). See #7344.
+          expect(indexGarden).toBeLessThan(indexMuseum)
+          expect(mostActivePlaces[indexGarden].base_position).toBe("20,20")
+          expect(mostActivePlaces[indexMuseum].base_position).toBe("10,10")
         })
       })
     })


### PR DESCRIPTION
## Changes

The `/api/destinations` **Most Active** sort (`order_by=most_active`) now orders by the **realtime connected-user count** for both places and worlds, instead of a hot-scenes-only boolean (`is_most_active_place`) that hardcoded worlds to `0`.

- The counts the route already holds in cache are injected into the query as a `live_user_count` column (a `CASE` with bound params — no string interpolation):
  - **places** → hot-scenes `usersTotalCount`, matched by `base_position`
  - **worlds** → world live-data `users`, matched by `world_name`
- `ORDER BY live_user_count DESC` in all three branches (`only_places`, `only_worlds`, UNION).
- **Additive**: when `order_by` ≠ `most_active`, nothing changes (no `live_user_count` column, no ORDER BY reference).
- **No migration, no new DB writes, no extra per-request load** — uses the existing minutely caches.

Fixes the backend ordering behind decentraland/unity-explorer#7344 — worlds (e.g. Meta GamiMall) and realtime-active places (e.g. La Cantina) were never surfaced under "Most Active".

## Scope note

Ordering uses the cheap cached sources (hot-scenes + world live-data). Folding pure comms-gatekeeper realtime (a live-event place absent from hot-scenes) into the ORDER is a possible later add-on; today that data is already surfaced for display via `with_connected_users`.

## Test plan

- [ ] Most Active surfaces active **worlds**, ranked by their live users.
- [ ] A place with more current users ranks above one with fewer, regardless of like_score.
- [ ] `order_by` ≠ `most_active` is unchanged.
- [ ] No live data available → no error; falls back to the like_score tiebreak.