### PR TITLE
fix: refresh world display metadata on scene redeploy

### DIFF
--- a/src/entities/CheckScenes/task/taskRunnerSqs.test.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.test.ts
@@ -1,0 +1,180 @@
+import {
+  ContentEntityScene,
+  SceneContentRating,
+} from "decentraland-gatsby/dist/utils/api/Catalyst.types"
+
+import { extractSceneJsonData } from "./extractSceneJsonData"
+import { createPlaceFromContentEntityScene } from "./processContentEntityScene"
+import { processEntityId } from "./processEntityId"
+import { taskRunnerSqs } from "./taskRunnerSqs"
+import { sqsMessageWorld } from "../../../__data__/sqs"
+import { worldContentEntitySceneParalax } from "../../../__data__/world"
+import PlaceModel from "../../Place/model"
+import WorldModel from "../../World/model"
+import { fetchNameOwner, findNewDeployedPlace } from "../utils"
+
+jest.mock("./processEntityId")
+jest.mock("./extractSceneJsonData")
+jest.mock("./processContentEntityScene")
+jest.mock("../utils", () => ({
+  fetchNameOwner: jest.fn(),
+  findNewDeployedPlace: jest.fn(),
+  updateGenesisCityManifest: jest.fn(),
+}))
+jest.mock("../../World/model", () => ({
+  __esModule: true,
+  default: {
+    insertWorldIfNotExists: jest.fn(),
+    upsertWorld: jest.fn(),
+  },
+}))
+jest.mock("../../Place/model", () => ({
+  __esModule: true,
+  default: {
+    findActiveByWorldIdAndPositions: jest.fn(),
+    findEnabledByPositions: jest.fn(),
+    insertPlace: jest.fn(),
+    updatePlace: jest.fn(),
+    disablePlaces: jest.fn(),
+    overrideCategories: jest.fn(),
+  },
+}))
+jest.mock("../../PlaceContentRating/model", () => ({
+  __esModule: true,
+  default: { create: jest.fn() },
+}))
+jest.mock("../../PlacePosition/model", () => ({
+  __esModule: true,
+  default: { syncBasePosition: jest.fn(), removePositions: jest.fn() },
+}))
+jest.mock("../../Slack/utils", () => ({
+  notifyNewPlace: jest.fn(),
+  notifyUpdatePlace: jest.fn(),
+  notifyDisablePlaces: jest.fn(),
+}))
+jest.mock("../model", () => ({
+  __esModule: true,
+  default: { createOne: jest.fn(), createMany: jest.fn() },
+}))
+
+const mockProcessEntityId = processEntityId as jest.MockedFunction<
+  typeof processEntityId
+>
+const mockExtractSceneJsonData = extractSceneJsonData as jest.MockedFunction<
+  typeof extractSceneJsonData
+>
+const mockCreatePlace =
+  createPlaceFromContentEntityScene as jest.MockedFunction<
+    typeof createPlaceFromContentEntityScene
+  >
+const mockFetchNameOwner = fetchNameOwner as jest.MockedFunction<
+  typeof fetchNameOwner
+>
+const mockFindNewDeployedPlace = findNewDeployedPlace as jest.MockedFunction<
+  typeof findNewDeployedPlace
+>
+
+const WORLD_NAME = "paralax.dcl.eth"
+const NAME_OWNER = "0x1111111111111111111111111111111111111111"
+
+// A world (re)deploy whose scene carries fresh display metadata and an SDK
+// content rating, modelled on the existing world fixture.
+function buildWorldScene(
+  display: { title?: string; description?: string },
+  contentRating: SceneContentRating
+): ContentEntityScene {
+  return {
+    ...worldContentEntitySceneParalax,
+    metadata: {
+      ...worldContentEntitySceneParalax.metadata,
+      display: {
+        ...worldContentEntitySceneParalax.metadata.display,
+        ...display,
+      },
+      tags: [],
+      policy: {
+        contentRating,
+        fly: true,
+        voiceEnabled: true,
+        blacklist: [],
+        teleportPosition: "0,0,0",
+      },
+    },
+  }
+}
+
+describe("taskRunnerSqs", () => {
+  describe("when a world scene is deployed", () => {
+    let upsertArg: Record<string, unknown>
+
+    beforeEach(async () => {
+      mockProcessEntityId.mockResolvedValue(
+        buildWorldScene(
+          { title: "Updated Title", description: "Updated description" },
+          SceneContentRating.TEEN
+        )
+      )
+      mockExtractSceneJsonData.mockResolvedValue({
+        creator: null,
+        runtimeVersion: null,
+      })
+      mockFetchNameOwner.mockResolvedValue(NAME_OWNER)
+      mockFindNewDeployedPlace.mockReturnValue(null)
+      mockCreatePlace.mockReturnValue({
+        id: "place-1",
+        positions: ["0,0"],
+        base_position: "0,0",
+        content_rating: SceneContentRating.TEEN,
+      } as unknown as ReturnType<typeof createPlaceFromContentEntityScene>)
+      ;(WorldModel.insertWorldIfNotExists as jest.Mock).mockResolvedValue(
+        WORLD_NAME
+      )
+      ;(WorldModel.upsertWorld as jest.Mock).mockResolvedValue({})
+      ;(
+        PlaceModel.findActiveByWorldIdAndPositions as jest.Mock
+      ).mockResolvedValue([])
+      ;(PlaceModel.insertPlace as jest.Mock).mockResolvedValue(undefined)
+
+      await taskRunnerSqs(sqsMessageWorld)
+
+      upsertArg = (WorldModel.upsertWorld as jest.Mock).mock.calls[0][0]
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("should set content_rating on the first insert", () => {
+      expect(WorldModel.insertWorldIfNotExists).toHaveBeenCalledWith(
+        expect.objectContaining({
+          world_name: WORLD_NAME,
+          content_rating: SceneContentRating.TEEN,
+        })
+      )
+    })
+
+    it("should refresh the world title and description from the latest scene display", () => {
+      expect(upsertArg).toMatchObject({
+        world_name: WORLD_NAME,
+        title: "Updated Title",
+        description: "Updated description",
+      })
+    })
+
+    it("should keep the world owner in sync with the on-chain name owner", () => {
+      expect(upsertArg.owner).toBe(NAME_OWNER)
+    })
+
+    it("should not clobber moderator-managed fields on redeploy", () => {
+      expect(upsertArg).not.toHaveProperty("content_rating")
+      expect(upsertArg).not.toHaveProperty("categories")
+      expect(upsertArg).not.toHaveProperty("highlighted")
+      expect(upsertArg).not.toHaveProperty("ranking")
+      expect(upsertArg).not.toHaveProperty("show_in_places")
+    })
+
+    it("should not write an image so the world keeps falling back to the latest place thumbnail", () => {
+      expect(upsertArg).not.toHaveProperty("image")
+    })
+  })
+})

--- a/src/entities/CheckScenes/task/taskRunnerSqs.test.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.test.ts
@@ -177,4 +177,61 @@ describe("taskRunnerSqs", () => {
       expect(upsertArg).not.toHaveProperty("image")
     })
   })
+
+  describe("when a world scene is deployed and the name has no on-chain owner", () => {
+    let upsertArg: Record<string, unknown>
+
+    beforeEach(async () => {
+      mockProcessEntityId.mockResolvedValue(
+        buildWorldScene(
+          { title: "Ownerless Title", description: "Ownerless description" },
+          SceneContentRating.TEEN
+        )
+      )
+      mockExtractSceneJsonData.mockResolvedValue({
+        creator: null,
+        runtimeVersion: null,
+      })
+      // No resolvable on-chain owner for this name.
+      mockFetchNameOwner.mockResolvedValue(undefined)
+      mockFindNewDeployedPlace.mockReturnValue(null)
+      mockCreatePlace.mockReturnValue({
+        id: "place-1",
+        positions: ["0,0"],
+        base_position: "0,0",
+        content_rating: SceneContentRating.TEEN,
+      } as unknown as ReturnType<typeof createPlaceFromContentEntityScene>)
+      ;(WorldModel.insertWorldIfNotExists as jest.Mock).mockResolvedValue(
+        WORLD_NAME
+      )
+      ;(WorldModel.upsertWorld as jest.Mock).mockResolvedValue({})
+      ;(
+        PlaceModel.findActiveByWorldIdAndPositions as jest.Mock
+      ).mockResolvedValue([])
+      ;(PlaceModel.insertPlace as jest.Mock).mockResolvedValue(undefined)
+
+      await taskRunnerSqs(sqsMessageWorld)
+
+      upsertArg = (WorldModel.upsertWorld as jest.Mock).mock.calls[0][0]
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("should still refresh the world title and description", () => {
+      expect(upsertArg).toMatchObject({
+        world_name: WORLD_NAME,
+        title: "Ownerless Title",
+        description: "Ownerless description",
+      })
+    })
+
+    it("should pass owner as undefined so a null name owner does not null out an existing owner", () => {
+      // `owner: nameOwner || undefined` resolves to undefined when the name has
+      // no on-chain owner, and upsertWorld only writes non-undefined fields —
+      // so an existing world owner is preserved on an ownerless redeploy.
+      expect(upsertArg.owner).toBeUndefined()
+    })
+  })
 })

--- a/src/entities/CheckScenes/task/taskRunnerSqs.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.ts
@@ -129,14 +129,22 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
       show_in_places: !isOptOut,
     })
 
-    // Update the world owner on every deployment to keep it in sync with
-    // the current on-chain name ownership.
-    if (nameOwner) {
-      await WorldModel.upsertWorld({
-        world_name: worldName,
-        owner: nameOwner,
-      })
-    }
+    // Refresh the world's display metadata on every (re)deploy so the world
+    // card reflects the current scene, and keep the owner in sync with the
+    // on-chain name ownership. upsertWorld only writes the fields explicitly
+    // passed here, so moderator-managed fields (content_rating, categories,
+    // highlighted, ranking, show_in_places) set on first insert are never
+    // clobbered on redeploy. `image` is intentionally omitted so the world
+    // keeps falling back to the latest place thumbnail via
+    // COALESCE(w.image, lp.image) instead of freezing a stale image.
+    await WorldModel.upsertWorld({
+      world_name: worldName,
+      title:
+        contentEntityScene?.metadata?.display?.title?.slice(0, 50) || undefined,
+      description:
+        contentEntityScene?.metadata?.display?.description || undefined,
+      owner: nameOwner || undefined,
+    })
 
     // World-specific overlap logic: in worlds, positions can change freely
     // between deployments, so identity is based on overlap count rather than

--- a/test/fixtures/deploymentEvent.ts
+++ b/test/fixtures/deploymentEvent.ts
@@ -71,6 +71,7 @@ export function createWorldContentEntityScene(
     metadata: {
       display: {
         title: overrides.title ?? "Test World Scene",
+        description: overrides.description,
         favicon: "favicon_asset",
         navmapThumbnail: "scene-thumbnail.png",
       },

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -150,6 +150,7 @@ describe("taskRunnerSqs integration", () => {
       const initialScene = createWorldContentEntityScene({
         worldName: "existingworld.dcl.eth",
         title: "Original Scene",
+        contentRating: "T",
       })
 
       mockProcessEntityId.mockResolvedValueOnce(initialScene)
@@ -160,11 +161,13 @@ describe("taskRunnerSqs integration", () => {
 
       await taskRunnerSqs(job)
 
-      // Second deployment updates the existing scene
+      // Second deployment updates the existing scene with new display metadata
+      // and a different content rating.
       const updatedScene = createWorldContentEntityScene({
         worldName: "existingworld.dcl.eth",
         title: "Updated Scene",
         description: "Updated description",
+        contentRating: "A",
       })
 
       mockProcessEntityId.mockResolvedValueOnce(updatedScene)
@@ -186,15 +189,25 @@ describe("taskRunnerSqs integration", () => {
       expect(response.body.data[0].title).toBe("Updated Scene")
     })
 
-    it("should not overwrite the world record with data from the second deployment", async () => {
+    it("should refresh the world title and description from the second deployment", async () => {
       const response = await supertest(app)
         .get("/api/worlds/existingworld.dcl.eth")
         .expect(200)
 
       expect(response.body.ok).toBe(true)
       expect(response.body.data.world_name).toBe("existingworld.dcl.eth")
-      expect(response.body.data.title).toBe("Original Scene")
-      expect(response.body.data.description).toBeNull()
+      expect(response.body.data.title).toBe("Updated Scene")
+      expect(response.body.data.description).toBe("Updated description")
+    })
+
+    it("should preserve the world content rating set on the first deployment", async () => {
+      const response = await supertest(app)
+        .get("/api/worlds/existingworld.dcl.eth")
+        .expect(200)
+
+      // content_rating is moderator-managed: only set on first insert, never
+      // clobbered by a redeploy even when the scene reports a different rating.
+      expect(response.body.data.content_rating).toBe("T")
     })
 
     it("should reflect updated data via the place detail API", async () => {


### PR DESCRIPTION
A World's `title`/`description`/`content_rating`/`categories` were written only on the first scene deploy — `insertWorldIfNotExists` uses `INSERT ... ON CONFLICT (id) DO NOTHING` — and never refreshed afterwards; only `owner` was kept in sync. As a result a World kept the title of whatever scene was first deployed to it, even after that scene changed.

On every (re)deploy the CheckScenes task now upserts the World's `title` and `description` from the latest scene's `metadata.display`. `upsertWorld` writes only the fields explicitly passed, so moderator-managed fields (`content_rating`, `categories`, `highlighted`, `ranking`, `show_in_places`) set on first insert are never clobbered on redeploy. `image` is intentionally not written so the World keeps falling back to the latest place thumbnail via `COALESCE(w.image, lp.image)` instead of freezing a stale image.

Existing frozen Worlds will not self-heal retroactively; they refresh on their next post-fix deploy. No backfill migration is included — the repo has no precedent for a data-derivation migration of this kind — but a one-off backfill that re-derives `title`/`description` from each World's latest active place can follow separately if immediate correction is needed.

Verified with `npm run lint`, `npm run build`, and `npm test`. Added a task test asserting that a redeploy with a new `display.title` updates the World title while leaving `content_rating` untouched. The only failing unit test in the suite, `Place/migration.test.ts`, fails on a live Catalyst fetch and is unrelated to this change.
