### PR TITLE
fix: cancel undrained native-fetch response bodies and bump decentraland-gatsby to 8.4.6

### DIFF
--- a/bin/populateSdk.ts
+++ b/bin/populateSdk.ts
@@ -67,6 +67,9 @@ async function fetchSceneJsonFromContent(
     const response = await fetch(contentUrl)
 
     if (!response.ok) {
+      if (!response.bodyUsed) {
+        await response.body?.cancel().catch(() => undefined)
+      }
       return null
     }
 
@@ -90,6 +93,9 @@ async function fetchWorldRuntimeVersion(
     const aboutResponse = await fetch(entityUrl)
 
     if (!aboutResponse.ok) {
+      if (!aboutResponse.bodyUsed) {
+        await aboutResponse.body?.cancel().catch(() => undefined)
+      }
       return null
     }
 
@@ -115,6 +121,9 @@ async function fetchWorldRuntimeVersion(
     const contentResponse = await fetch(contentUrl)
 
     if (!contentResponse.ok) {
+      if (!contentResponse.bodyUsed) {
+        await contentResponse.body?.cancel().catch(() => undefined)
+      }
       return null
     }
 
@@ -141,6 +150,9 @@ async function fetchWorldRuntimeVersion(
     const sceneJsonResponse = await fetch(sceneJsonUrl)
 
     if (!sceneJsonResponse.ok) {
+      if (!sceneJsonResponse.bodyUsed) {
+        await sceneJsonResponse.body?.cancel().catch(() => undefined)
+      }
       return null
     }
 

--- a/bin/populateSdk.ts
+++ b/bin/populateSdk.ts
@@ -25,6 +25,8 @@
  */
 
 import logger from "decentraland-gatsby/dist/entities/Development/logger"
+
+import { drainResponse } from "../src/utils/fetch"
 import Catalyst from "decentraland-gatsby/dist/utils/api/Catalyst"
 import { ContentEntityScene } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 import env from "decentraland-gatsby/dist/utils/env"
@@ -67,9 +69,7 @@ async function fetchSceneJsonFromContent(
     const response = await fetch(contentUrl)
 
     if (!response.ok) {
-      if (!response.bodyUsed) {
-        await response.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(response)
       return null
     }
 
@@ -93,9 +93,7 @@ async function fetchWorldRuntimeVersion(
     const aboutResponse = await fetch(entityUrl)
 
     if (!aboutResponse.ok) {
-      if (!aboutResponse.bodyUsed) {
-        await aboutResponse.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(aboutResponse)
       return null
     }
 
@@ -121,9 +119,7 @@ async function fetchWorldRuntimeVersion(
     const contentResponse = await fetch(contentUrl)
 
     if (!contentResponse.ok) {
-      if (!contentResponse.bodyUsed) {
-        await contentResponse.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(contentResponse)
       return null
     }
 
@@ -150,9 +146,7 @@ async function fetchWorldRuntimeVersion(
     const sceneJsonResponse = await fetch(sceneJsonUrl)
 
     if (!sceneJsonResponse.ok) {
-      if (!sceneJsonResponse.bodyUsed) {
-        await sceneJsonResponse.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(sceneJsonResponse)
       return null
     }
 

--- a/bin/rebuildWorldPlaces.ts
+++ b/bin/rebuildWorldPlaces.ts
@@ -215,6 +215,9 @@ async function fetchAllWorlds(
     const url = `${baseUrl}/worlds?has_deployed_scenes=true&limit=${WORLDS_PAGE_SIZE}&offset=${offset}`
     const response = await fetch(url)
     if (!response.ok) {
+      if (!response.bodyUsed) {
+        await response.body?.cancel().catch(() => undefined)
+      }
       throw new Error(
         `Failed to fetch worlds list: ${response.status} ${response.statusText}`
       )
@@ -246,6 +249,9 @@ async function fetchWorldScenes(
   const url = `${baseUrl}/world/${encodeURIComponent(worldName)}/scenes`
   const response = await fetch(url)
   if (!response.ok) {
+    if (!response.bodyUsed) {
+      await response.body?.cancel().catch(() => undefined)
+    }
     throw new Error(
       `Failed to fetch scenes for ${worldName}: ${response.status} ${response.statusText}`
     )

--- a/bin/rebuildWorldPlaces.ts
+++ b/bin/rebuildWorldPlaces.ts
@@ -24,6 +24,8 @@
 
 import { randomUUID } from "crypto"
 
+import { drainResponse } from "../src/utils/fetch"
+
 import database from "decentraland-gatsby/dist/entities/Database/database"
 import logger from "decentraland-gatsby/dist/entities/Development/logger"
 import {
@@ -215,9 +217,7 @@ async function fetchAllWorlds(
     const url = `${baseUrl}/worlds?has_deployed_scenes=true&limit=${WORLDS_PAGE_SIZE}&offset=${offset}`
     const response = await fetch(url)
     if (!response.ok) {
-      if (!response.bodyUsed) {
-        await response.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(response)
       throw new Error(
         `Failed to fetch worlds list: ${response.status} ${response.statusText}`
       )
@@ -249,9 +249,7 @@ async function fetchWorldScenes(
   const url = `${baseUrl}/world/${encodeURIComponent(worldName)}/scenes`
   const response = await fetch(url)
   if (!response.ok) {
-    if (!response.bodyUsed) {
-      await response.body?.cancel().catch(() => undefined)
-    }
+    await drainResponse(response)
     throw new Error(
       `Failed to fetch scenes for ${worldName}: ${response.status} ${response.statusText}`
     )

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dcl/schemas": "^25.0.0",
         "@well-known-components/pushable-channel": "^1.0.3",
         "aws-sdk": "^2.1002.0",
-        "decentraland-gatsby": "^8.4.5",
+        "decentraland-gatsby": "^8.4.6",
         "html-escaper": "^3.0.3",
         "node-pg-migrate": "^6.0.0",
         "pg": "^8.13.1",
@@ -3735,9 +3735,9 @@
       }
     },
     "node_modules/@dcl/http-server": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.0.3.tgz",
-      "integrity": "sha512-viIRBUk0Gnh39CgpOUXHjXfK85PYejvkScTlHAwAyUFHir01Qh3FMztZUOcO9uEEdbMXdJf7HuJfSDbXJv1gNw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@dcl/http-server/-/http-server-2.1.0.tgz",
+      "integrity": "sha512-UqIFIo18JeKklM/RM0wEJ0u/DCGjikBHtQ1LzuQKjDK6SP9XgeVhukgCg5BmdW0D3Qzlql2i5CGpW4EdyfUiWQ==",
       "dependencies": {
         "@dcl/core-commons": "0.10.1",
         "@well-known-components/interfaces": "^1.5.1",
@@ -20697,43 +20697,6 @@
         "tslib": "^2.8.1"
       }
     },
-    "node_modules/decentraland-connect/node_modules/@base-org/account": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.5.5.tgz",
-      "integrity": "sha512-WKXygJv/fAE4TcmkGW0ibfYEiZKrhxFlTjkrv8KIdRQ5AiQADfSVhcscWeYVeNMvsVtwS8dzpGEQcmqhpvePnw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@coinbase/cdp-sdk": "^1.0.0",
-        "brotli-wasm": "^3.0.0",
-        "clsx": "1.2.1",
-        "eventemitter3": "5.0.1",
-        "idb-keyval": "6.2.1",
-        "ox": "0.6.9",
-        "preact": "10.24.2",
-        "viem": "^2.31.7",
-        "zustand": "5.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/decentraland-connect/node_modules/@coinbase/wallet-sdk": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.7.tgz",
-      "integrity": "sha512-z6e5XDw6EF06RqkeyEa+qD0dZ2ZbLci99vx3zwDY//XO8X7166tqKJrR2XlQnzVmtcUuJtCd5fCvr9Cu6zzX7w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "^1.4.0",
-        "clsx": "^1.2.1",
-        "eventemitter3": "^5.0.1",
-        "preact": "^10.24.2",
-        "viem": "^2.27.2"
-      }
-    },
     "node_modules/decentraland-connect/node_modules/@emotion/styled": {
       "version": "11.14.1",
       "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.14.1.tgz",
@@ -22520,9 +22483,9 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.5.tgz",
-      "integrity": "sha512-qqLEf35cf/1lPdka65dcBoRdqQf5kolSCI1HshqKm7+NYOzlE6Xwi0rLNL0Wvx1C9TragjwUtXhCHYSLfGku8w==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.6.tgz",
+      "integrity": "sha512-V72OrZzLWOvEY/GC4a3GZBAnN+Y/wlPVhdU6IS9W5KHC8aYcWwSpTybBsBV7GVoc9H/c92z8sVC43IauHkz6Sw==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",
@@ -22530,7 +22493,7 @@
         "@dcl/crypto": "^3.4.3",
         "@dcl/crypto-middleware": "^4.0.0",
         "@dcl/feature-flags": "^1.2.0",
-        "@dcl/http-server": "^2.0.1",
+        "@dcl/http-server": "^2.1.0",
         "@dcl/schemas": "^25.1.0",
         "@dcl/single-sign-on-client": "^0.1.0",
         "@dcl/ui-env": "^2.0.0",
@@ -42718,43 +42681,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/wagmi/node_modules/@base-org/account": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.5.5.tgz",
-      "integrity": "sha512-WKXygJv/fAE4TcmkGW0ibfYEiZKrhxFlTjkrv8KIdRQ5AiQADfSVhcscWeYVeNMvsVtwS8dzpGEQcmqhpvePnw==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@coinbase/cdp-sdk": "^1.0.0",
-        "brotli-wasm": "^3.0.0",
-        "clsx": "1.2.1",
-        "eventemitter3": "5.0.1",
-        "idb-keyval": "6.2.1",
-        "ox": "0.6.9",
-        "preact": "10.24.2",
-        "viem": "^2.31.7",
-        "zustand": "5.0.3"
-      },
-      "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/wagmi/node_modules/@coinbase/wallet-sdk": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.7.tgz",
-      "integrity": "sha512-z6e5XDw6EF06RqkeyEa+qD0dZ2ZbLci99vx3zwDY//XO8X7166tqKJrR2XlQnzVmtcUuJtCd5fCvr9Cu6zzX7w==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@noble/hashes": "^1.4.0",
-        "clsx": "^1.2.1",
-        "eventemitter3": "^5.0.1",
-        "preact": "^10.24.2",
-        "viem": "^2.27.2"
       }
     },
     "node_modules/wagmi/node_modules/@wagmi/connectors": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/schemas": "^25.0.0",
     "@well-known-components/pushable-channel": "^1.0.3",
     "aws-sdk": "^2.1002.0",
-    "decentraland-gatsby": "^8.4.5",
+    "decentraland-gatsby": "^8.4.6",
     "html-escaper": "^3.0.3",
     "node-pg-migrate": "^6.0.0",
     "pg": "^8.13.1",

--- a/src/entities/CheckScenes/task/extractSceneJsonData.ts
+++ b/src/entities/CheckScenes/task/extractSceneJsonData.ts
@@ -1,5 +1,7 @@
 import { ContentEntityScene } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 
+import { drainResponse } from "../../../utils/fetch"
+
 export type SceneJsonData = {
   creator: string | null
   runtimeVersion: string | null
@@ -34,9 +36,7 @@ export async function extractSceneJsonData(
     const response = await fetch(contentUrl)
 
     if (!response.ok) {
-      if (!response.bodyUsed) {
-        await response.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(response)
       return { creator: null, runtimeVersion: null }
     }
 

--- a/src/entities/CheckScenes/task/extractSceneJsonData.ts
+++ b/src/entities/CheckScenes/task/extractSceneJsonData.ts
@@ -34,6 +34,9 @@ export async function extractSceneJsonData(
     const response = await fetch(contentUrl)
 
     if (!response.ok) {
+      if (!response.bodyUsed) {
+        await response.body?.cancel().catch(() => undefined)
+      }
       return { creator: null, runtimeVersion: null }
     }
 

--- a/src/entities/CheckScenes/utils.test.ts
+++ b/src/entities/CheckScenes/utils.test.ts
@@ -217,6 +217,31 @@ describe("fetchNameOwner", () => {
     })
   })
 
+  describe("when the ENS subgraph response is not ok", () => {
+    let result: string | undefined
+    let cancel: jest.Mock
+
+    beforeEach(async () => {
+      cancel = jest.fn().mockResolvedValue(undefined)
+      jest.spyOn(global, "fetch").mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        bodyUsed: false,
+        body: { cancel },
+      } as unknown as Response)
+
+      result = await fetchNameOwner("myworld.eth")
+    })
+
+    it("should return undefined", () => {
+      expect(result).toBeUndefined()
+    })
+
+    it("should release the response body", () => {
+      expect(cancel).toHaveBeenCalledTimes(1)
+    })
+  })
+
   describe("when the fetch throws an error", () => {
     let result: string | undefined
 

--- a/src/entities/CheckScenes/utils.ts
+++ b/src/entities/CheckScenes/utils.ts
@@ -6,6 +6,7 @@ import env from "decentraland-gatsby/dist/utils/env"
 import allCoordinates from "../../__data__/AllCoordinates.json"
 import roadCoordinates from "../../__data__/RoadCoordinates.json"
 import areSamePositions from "../../utils/array/areSamePositions"
+import { drainResponse } from "../../utils/fetch"
 import { PlaceAttributes } from "../Place/types"
 import PlacePositionModel from "../PlacePosition/model"
 
@@ -85,9 +86,7 @@ async function fetchDclNameOwner(
   })
 
   if (!response.ok) {
-    if (!response.bodyUsed) {
-      await response.body?.cancel().catch(() => undefined)
-    }
+    await drainResponse(response)
     return undefined
   }
 
@@ -121,9 +120,7 @@ async function fetchEnsNameOwner(
   })
 
   if (!response.ok) {
-    if (!response.bodyUsed) {
-      await response.body?.cancel().catch(() => undefined)
-    }
+    await drainResponse(response)
     return undefined
   }
 

--- a/src/entities/CheckScenes/utils.ts
+++ b/src/entities/CheckScenes/utils.ts
@@ -85,6 +85,9 @@ async function fetchDclNameOwner(
   })
 
   if (!response.ok) {
+    if (!response.bodyUsed) {
+      await response.body?.cancel().catch(() => undefined)
+    }
     return undefined
   }
 
@@ -118,6 +121,9 @@ async function fetchEnsNameOwner(
   })
 
   if (!response.ok) {
+    if (!response.bodyUsed) {
+      await response.body?.cancel().catch(() => undefined)
+    }
     return undefined
   }
 

--- a/src/entities/RealmProvider/utils.ts
+++ b/src/entities/RealmProvider/utils.ts
@@ -42,6 +42,9 @@ export default class RealmProvider {
         signal: controller.signal,
       })
       if (!response.ok) {
+        if (!response.bodyUsed) {
+          await response.body?.cancel().catch(() => undefined)
+        }
         throw new Error(`Failed to fetch hot scenes: ${response.statusText}`)
       }
       return await response.json()

--- a/src/entities/RealmProvider/utils.ts
+++ b/src/entities/RealmProvider/utils.ts
@@ -1,6 +1,7 @@
 import Time from "decentraland-gatsby/dist/utils/date/Time"
 import env from "decentraland-gatsby/dist/utils/env"
 
+import { drainResponse } from "../../utils/fetch"
 import { HotScene } from "../Place/types"
 
 const DEFAULT_HOST_SCENE = [] as HotScene[]
@@ -42,9 +43,7 @@ export default class RealmProvider {
         signal: controller.signal,
       })
       if (!response.ok) {
-        if (!response.bodyUsed) {
-          await response.body?.cancel().catch(() => undefined)
-        }
+        await drainResponse(response)
         throw new Error(`Failed to fetch hot scenes: ${response.statusText}`)
       }
       return await response.json()

--- a/src/entities/SceneStats/utils.ts
+++ b/src/entities/SceneStats/utils.ts
@@ -28,6 +28,9 @@ export default class DataTeam {
   async getSceneStats(): Promise<SceneStatsMap> {
     const response = await fetch(`${this.url}scenes/scene-stats.json`)
     if (!response.ok) {
+      if (!response.bodyUsed) {
+        await response.body?.cancel().catch(() => undefined)
+      }
       throw new Error(`Failed to fetch scene stats: ${response.statusText}`)
     }
 

--- a/src/entities/SceneStats/utils.ts
+++ b/src/entities/SceneStats/utils.ts
@@ -1,6 +1,7 @@
 import env from "decentraland-gatsby/dist/utils/env"
 
 import { SceneStatsMap } from "./types"
+import { drainResponse } from "../../utils/fetch"
 
 export default class DataTeam {
   static Url = env("DATA_TEAM_URL", "https://cdn-data.decentraland.org/")
@@ -28,9 +29,7 @@ export default class DataTeam {
   async getSceneStats(): Promise<SceneStatsMap> {
     const response = await fetch(`${this.url}scenes/scene-stats.json`)
     if (!response.ok) {
-      if (!response.bodyUsed) {
-        await response.body?.cancel().catch(() => undefined)
-      }
+      await drainResponse(response)
       throw new Error(`Failed to fetch scene stats: ${response.statusText}`)
     }
 

--- a/src/utils/fetch.ts
+++ b/src/utils/fetch.ts
@@ -1,0 +1,12 @@
+/**
+ * Releases an unconsumed native `fetch` Response body so the underlying connection
+ * is freed instead of being pinned until GC. Best-effort: it skips bodies that were
+ * already read and ignores cancel errors (e.g. an already-closed stream). Use it on
+ * discard paths — early returns, throws, or fire-and-forget — where the body would
+ * otherwise never be consumed.
+ */
+export async function drainResponse(response: Response): Promise<void> {
+  if (!response.bodyUsed) {
+    await response.body?.cancel().catch(() => undefined)
+  }
+}


### PR DESCRIPTION
## What

Bumps `decentraland-gatsby` and releases native-fetch (undici) response bodies on the discard paths that previously left a `Response` undrained. Under Node's native `fetch`, a `Response` whose body is neither read nor cancelled keeps the underlying connection/socket pinned until GC, which can exhaust the connection pool. This was masked by `node-fetch`, which auto-drained.

## Changes

### Dependency bump

- `decentraland-gatsby`: `^8.4.5` -> `^8.4.6` (lockfile resolves to `8.4.6`; transitively pulls `@dcl/http-server` `2.0.3` -> `2.1.0` and prunes optional/peer `@base-org/account` sub-deps).
- No `node-fetch` / `isomorphic-fetch` / `cross-fetch` change: none was ever a direct dependency (they appear only transitively), and none is imported in `src/` or `bin/`, so there was nothing to drop.

### Response-body release on discard paths

Each site below has an explicit non-ok early `return`/`throw` that ran before the body was read. The fix drains the body first, guarded so it never touches an already-consumed stream:

```ts
if (!response.bodyUsed) {
  await response.body?.cancel().catch(() => undefined)
}
```

Server-side (`src/`):

- `src/entities/SceneStats/utils.ts` — `DataTeam.getSceneStats()`: `if (!response.ok) { throw }` (scene-stats GET).
- `src/entities/CheckScenes/utils.ts` — `fetchDclNameOwner()`: `if (!response.ok) { return undefined }` (Marketplace subgraph POST).
- `src/entities/CheckScenes/utils.ts` — `fetchEnsNameOwner()`: `if (!response.ok) { return undefined }` (ENS subgraph POST).
- `src/entities/CheckScenes/task/extractSceneJsonData.ts` — `if (!response.ok) { return { creator: null, runtimeVersion: null } }` (content-server GET).
- `src/entities/RealmProvider/utils.ts` — `RealmProvider.getHotScenes()`: `if (!response.ok) { throw }` (hot-scenes GET).

Maintenance scripts (`bin/`):

- `bin/rebuildWorldPlaces.ts` — `fetchAllWorlds()`: `if (!response.ok) { throw }` (worlds-list GET).
- `bin/rebuildWorldPlaces.ts` — `fetchWorldScenes()`: `if (!response.ok) { throw }` (world-scenes GET).
- `bin/populateSdk.ts` — `fetchSceneJsonFromContent()`: `if (!response.ok) { return null }`.
- `bin/populateSdk.ts` — `fetchWorldRuntimeVersion()` aboutResponse: `if (!aboutResponse.ok) { return null }`.
- `bin/populateSdk.ts` — `fetchWorldRuntimeVersion()` contentResponse: `if (!contentResponse.ok) { return null }`.
- `bin/populateSdk.ts` — `fetchWorldRuntimeVersion()` sceneJsonResponse: `if (!sceneJsonResponse.ok) { return null }`.

### Deliberately not changed

Fetch sites that read the body unconditionally on every non-throwing path have no undrained-discard branch, so they were left as-is:

- `src/modules/pois.ts`, `src/modules/worldsLiveData.ts`, `src/entities/World/utils.ts`, `src/entities/Snapshot/utils.ts` — call `await res.json()` unconditionally (no `.ok` gate).
- `src/entities/Slack/utils.ts` (both `sendToSlack` and `sendToContentModeratorSlack` webhook POSTs) — call `await response.text()` before the status check.

No frontend (`.tsx`) fetch was modified.

## Verification

- Typecheck `tsc -p .` (src): pass (exit 0).
- Standalone typecheck of the two edited `bin/` files (outside the `src`-scoped tsconfig include), using the project compiler options: pass (exit 0).
- Lint `eslint ./src`: pass (0 errors, 17 pre-existing warnings).
- Unit tests `jest`: pass — 32 suites, 259 passed, 1 skipped (260 total); the three directly-affected suites (CheckScenes/utils, RealmProvider/utils, SceneStats/utils) all pass.
- Integration tests (`test:integration`) require external infra (Postgres/localstack/redis) and were not run.

Note: linting the edited `bin/` files directly surfaces one `no-constant-condition` error on the pre-existing `while (true)` at `bin/rebuildWorldPlaces.ts:214`, which is verbatim on `master`, untouched by this diff, and outside the repo lint scope (`./src`). This change adds zero new lint problems.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
