### PR TITLE
feat: add admin endpoint to disable or re-enable a place

### DIFF
--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -496,9 +496,9 @@ export default class PlaceModel extends Model<PlaceAttributes> {
   static async updateDisabled(
     placeId: string,
     disabled: boolean,
-    reason: DisabledReason | null
+    reason: DisabledReason | null,
+    now: Date = new Date()
   ) {
-    const now = new Date()
     const sql = SQL`
       UPDATE ${table(this)}
       SET "disabled" = ${disabled},

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -25,6 +25,7 @@ function sanitizeSearch(search: string): string {
 
 import {
   AggregatePlaceAttributes,
+  DisabledReason,
   FindWithAggregatesOptions,
   HotScene,
   PlaceAttributes,
@@ -490,6 +491,23 @@ export default class PlaceModel extends Model<PlaceAttributes> {
       WHERE "id" = ANY(${placesIds})
     `
     await this.namedQuery("disable_places", sql)
+  }
+
+  static async updateDisabled(
+    placeId: string,
+    disabled: boolean,
+    reason: DisabledReason | null
+  ) {
+    const now = new Date()
+    const sql = SQL`
+      UPDATE ${table(this)}
+      SET "disabled" = ${disabled},
+        "disabled_at" = ${disabled ? now : null},
+        "disabled_reason" = ${disabled ? reason : null},
+        "updated_at" = ${now}
+      WHERE "id" = ${placeId}
+    `
+    await this.namedQuery("update_disabled", sql)
   }
 
   /**

--- a/src/entities/Place/routes/index.ts
+++ b/src/entities/Place/routes/index.ts
@@ -8,6 +8,7 @@ import { getPlaceCategories } from "./getPlaceCategories"
 import { getPlaceList } from "./getPlaceList"
 import { getPlaceListById } from "./getPlaceListById"
 import { getPlaceStatusListById } from "./getPlaceStatusListById"
+import { updateDisabled } from "./updateDisabled"
 import { updateHighlight } from "./updateHighlight"
 import { updateRanking } from "./updateRanking"
 import { updateRating } from "./updateRating"
@@ -38,6 +39,7 @@ export default routes((router) => {
   router.put("/places/:place_id/rating", updateRating)
   router.put("/places/:place_id/ranking", updateRanking)
   router.put("/places/:place_id/highlight", updateHighlight)
+  router.put("/places/:place_id/disable", updateDisabled)
   router.get("/places/:place_id/categories", getPlaceCategories)
   router.put("/places/:place_id/featured", featurePlace)
   router.delete("/places/:place_id/featured", unfeaturePlace)

--- a/src/entities/Place/routes/updateDisabled.test.ts
+++ b/src/entities/Place/routes/updateDisabled.test.ts
@@ -1,0 +1,198 @@
+import { randomUUID } from "crypto"
+
+import isAdmin from "decentraland-gatsby/dist/entities/Auth/isAdmin"
+import * as decentralandAuth from "decentraland-gatsby/dist/entities/Auth/routes/withDecentralandAuth"
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+
+import { placeGenesisPlazaWithAggregatedAttributes } from "../../../__data__/placeGenesisPlazaWithAggregatedAttributes"
+import { notifyDisablePlaces } from "../../Slack/utils"
+import PlaceModel from "../model"
+import { DisabledReason } from "../types"
+import { updateDisabled } from "./updateDisabled"
+
+jest.mock("decentraland-gatsby/dist/entities/Auth/isAdmin")
+jest.mock("../../Slack/utils")
+
+const place_id = randomUUID()
+const adminAddress = "0x1234567890123456789012345678901234567890"
+const nonAdminAddress = "0x0987654321098765432109876543210987654321"
+
+const mockWithAuth = jest.spyOn(decentralandAuth, "withAuth")
+const findByIdWithAggregates = jest.spyOn(PlaceModel, "findByIdWithAggregates")
+const updateDisabledModel = jest.spyOn(PlaceModel, "updateDisabled")
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockWithAuth.mockResolvedValue({
+    address: adminAddress,
+    metadata: {},
+  } as any)
+  ;(isAdmin as jest.Mock).mockReturnValue(true)
+  findByIdWithAggregates.mockResolvedValue({
+    ...placeGenesisPlazaWithAggregatedAttributes,
+    id: place_id,
+    disabled: false,
+    disabled_at: null,
+    disabled_reason: null,
+  } as any)
+  updateDisabledModel.mockResolvedValue([] as any)
+})
+
+describe("when updating the disabled status of a place", () => {
+  describe("when user is not authenticated", () => {
+    beforeEach(() => {
+      mockWithAuth.mockRejectedValue(new Error("Unauthorized"))
+    })
+
+    it("should throw unauthorized error", async () => {
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+      await expect(() =>
+        updateDisabled({
+          request,
+          params: { place_id },
+          body: { disabled: true },
+        })
+      ).rejects.toThrow("Unauthorized")
+    })
+  })
+
+  describe("when user is authenticated but not admin", () => {
+    beforeEach(() => {
+      mockWithAuth.mockResolvedValue({
+        address: nonAdminAddress,
+        metadata: {},
+      } as any)
+      ;(isAdmin as jest.Mock).mockReturnValue(false)
+    })
+
+    it("should throw forbidden error", async () => {
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+      await expect(() =>
+        updateDisabled({
+          request,
+          params: { place_id },
+          body: { disabled: true },
+        })
+      ).rejects.toThrow("Only admin allowed to update disabled")
+    })
+  })
+
+  describe("when user is admin", () => {
+    describe("and place does not exist", () => {
+      beforeEach(() => {
+        findByIdWithAggregates.mockResolvedValue(null as any)
+      })
+
+      it("should throw not found error", async () => {
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+        await expect(() =>
+          updateDisabled({
+            request,
+            params: { place_id },
+            body: { disabled: true },
+          })
+        ).rejects.toThrow(`Not found place "${place_id}"`)
+      })
+    })
+
+    describe("and place exists", () => {
+      it("should disable the place with moderation reason", async () => {
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+        const response = await updateDisabled({
+          request,
+          params: { place_id },
+          body: { disabled: true },
+        })
+
+        expect(updateDisabledModel).toHaveBeenCalledWith(
+          place_id,
+          true,
+          DisabledReason.MODERATION
+        )
+        expect(response.body).toEqual({
+          ok: true,
+          data: expect.objectContaining({
+            disabled: true,
+            disabled_reason: DisabledReason.MODERATION,
+          }),
+        })
+        expect(response.body.data.disabled_at).not.toBeNull()
+      })
+
+      it("should notify slack when disabling", async () => {
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+        await updateDisabled({
+          request,
+          params: { place_id },
+          body: { disabled: true },
+        })
+
+        expect(notifyDisablePlaces).toHaveBeenCalledWith([
+          expect.objectContaining({ id: place_id, disabled: true }),
+        ])
+      })
+
+      it("should re-enable the place and clear disabled fields", async () => {
+        findByIdWithAggregates.mockResolvedValue({
+          ...placeGenesisPlazaWithAggregatedAttributes,
+          id: place_id,
+          disabled: true,
+          disabled_at: new Date("2026-01-01"),
+          disabled_reason: DisabledReason.MODERATION,
+        } as any)
+
+        const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+        const response = await updateDisabled({
+          request,
+          params: { place_id },
+          body: { disabled: false },
+        })
+
+        expect(updateDisabledModel).toHaveBeenCalledWith(place_id, false, null)
+        expect(response.body).toEqual({
+          ok: true,
+          data: expect.objectContaining({
+            disabled: false,
+            disabled_at: null,
+            disabled_reason: null,
+          }),
+        })
+        expect(notifyDisablePlaces).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe("when place_id is invalid", () => {
+    it("should throw validation error", async () => {
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+      await expect(() =>
+        updateDisabled({
+          request,
+          params: { place_id: "invalid-uuid" },
+          body: { disabled: true },
+        })
+      ).rejects.toThrow()
+    })
+  })
+
+  describe("when body is invalid", () => {
+    it("should throw validation error for missing disabled field", async () => {
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+      await expect(() =>
+        updateDisabled({
+          request,
+          params: { place_id },
+          body: {} as any,
+        })
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/src/entities/Place/routes/updateDisabled.test.ts
+++ b/src/entities/Place/routes/updateDisabled.test.ts
@@ -111,7 +111,8 @@ describe("when updating the disabled status of a place", () => {
         expect(updateDisabledModel).toHaveBeenCalledWith(
           place_id,
           true,
-          DisabledReason.MODERATION
+          DisabledReason.MODERATION,
+          expect.any(Date)
         )
         expect(response.body).toEqual({
           ok: true,
@@ -154,7 +155,12 @@ describe("when updating the disabled status of a place", () => {
           body: { disabled: false },
         })
 
-        expect(updateDisabledModel).toHaveBeenCalledWith(place_id, false, null)
+        expect(updateDisabledModel).toHaveBeenCalledWith(
+          place_id,
+          false,
+          null,
+          expect.any(Date)
+        )
         expect(response.body).toEqual({
           ok: true,
           data: expect.objectContaining({
@@ -165,6 +171,70 @@ describe("when updating the disabled status of a place", () => {
         })
         expect(notifyDisablePlaces).not.toHaveBeenCalled()
       })
+    })
+  })
+
+  describe("when disabling an already disabled place", () => {
+    beforeEach(() => {
+      findByIdWithAggregates.mockResolvedValue({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        id: place_id,
+        disabled: true,
+        disabled_at: new Date("2026-01-01"),
+        disabled_reason: DisabledReason.MODERATION,
+      } as any)
+    })
+
+    it("should succeed idempotently", async () => {
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+      const response = await updateDisabled({
+        request,
+        params: { place_id },
+        body: { disabled: true },
+      })
+
+      expect(updateDisabledModel).toHaveBeenCalledWith(
+        place_id,
+        true,
+        DisabledReason.MODERATION,
+        expect.any(Date)
+      )
+      expect(response.body).toEqual({
+        ok: true,
+        data: expect.objectContaining({
+          disabled: true,
+          disabled_reason: DisabledReason.MODERATION,
+        }),
+      })
+    })
+  })
+
+  describe("when re-enabling an already enabled place", () => {
+    it("should succeed idempotently", async () => {
+      const request = new Request("http://0.0.0.0/", { method: "PUT" })
+
+      const response = await updateDisabled({
+        request,
+        params: { place_id },
+        body: { disabled: false },
+      })
+
+      expect(updateDisabledModel).toHaveBeenCalledWith(
+        place_id,
+        false,
+        null,
+        expect.any(Date)
+      )
+      expect(response.body).toEqual({
+        ok: true,
+        data: expect.objectContaining({
+          disabled: false,
+          disabled_at: null,
+          disabled_reason: null,
+        }),
+      })
+      expect(notifyDisablePlaces).not.toHaveBeenCalled()
     })
   })
 

--- a/src/entities/Place/routes/updateDisabled.ts
+++ b/src/entities/Place/routes/updateDisabled.ts
@@ -62,7 +62,8 @@ export async function updateDisabled(
   await PlaceModel.updateDisabled(
     params.place_id,
     body.disabled,
-    body.disabled ? DisabledReason.MODERATION : null
+    body.disabled ? DisabledReason.MODERATION : null,
+    now
   )
 
   if (body.disabled) {

--- a/src/entities/Place/routes/updateDisabled.ts
+++ b/src/entities/Place/routes/updateDisabled.ts
@@ -1,0 +1,73 @@
+import isAdmin from "decentraland-gatsby/dist/entities/Auth/isAdmin"
+import { withAuth } from "decentraland-gatsby/dist/entities/Auth/routes/withDecentralandAuth"
+import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
+import ApiResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ApiResponse"
+import ErrorResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ErrorResponse"
+import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Response"
+import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
+
+import { createWkcValidator } from "../../shared/validate"
+import { notifyDisablePlaces } from "../../Slack/utils"
+import PlaceModel from "../model"
+import { getPlaceParamsSchema, updateDisabledBodySchema } from "../schemas"
+import {
+  AggregatePlaceAttributes,
+  DisabledReason,
+  GetPlaceParams,
+  UpdateDisabledBody,
+} from "../types"
+
+const validateUpdateDisabledParams = createWkcValidator<GetPlaceParams>(
+  getPlaceParamsSchema as AjvObjectSchema
+)
+
+const validateUpdateDisabledBody = createWkcValidator<UpdateDisabledBody>(
+  updateDisabledBodySchema as AjvObjectSchema
+)
+
+export async function updateDisabled(
+  ctx: Context<{ place_id: string }, "request" | "body" | "params">
+): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
+  const userAuth = await withAuth(ctx)
+  const params = await validateUpdateDisabledParams(ctx.params)
+  const body = await validateUpdateDisabledBody(ctx.body)
+
+  if (!isAdmin(userAuth.address)) {
+    throw new ErrorResponse(
+      Response.Forbidden,
+      `Only admin allowed to update disabled`
+    )
+  }
+
+  const place = await PlaceModel.findByIdWithAggregates(params.place_id, {
+    user: userAuth.address,
+  })
+
+  if (!place) {
+    throw new ErrorResponse(
+      Response.NotFound,
+      `Not found place "${params.place_id}"`
+    )
+  }
+
+  const now = new Date()
+  const newPlace = {
+    ...place,
+    disabled: body.disabled,
+    disabled_at: body.disabled ? now : null,
+    disabled_reason: body.disabled ? DisabledReason.MODERATION : null,
+    updated_at: now,
+  }
+
+  await PlaceModel.updateDisabled(
+    params.place_id,
+    body.disabled,
+    body.disabled ? DisabledReason.MODERATION : null
+  )
+
+  if (body.disabled) {
+    notifyDisablePlaces([newPlace])
+  }
+
+  return new ApiResponse(newPlace)
+}

--- a/src/entities/Place/schemas.ts
+++ b/src/entities/Place/schemas.ts
@@ -246,8 +246,8 @@ export const placeSchema = schema({
     disabled_reason: {
       type: "string",
       description:
-        "The reason why the place is disabled: opt_out, undeployment, or overwritten",
-      enum: ["opt_out", "undeployment", "overwritten"],
+        "The reason why the place is disabled: opt_out, undeployment, overwritten, or moderation",
+      enum: ["opt_out", "undeployment", "overwritten", "moderation"],
       nullable: true as any,
     },
     created_at: {

--- a/src/entities/Place/schemas.ts
+++ b/src/entities/Place/schemas.ts
@@ -362,3 +362,17 @@ export const updateHighlightBodySchema = schema({
     },
   },
 })
+
+export const updateDisabledBodySchema = schema({
+  type: "object",
+  description: "Disabled update body",
+  additionalProperties: false,
+  required: ["disabled"],
+  properties: {
+    disabled: {
+      type: "boolean",
+      description:
+        "Whether the place should be disabled (hidden from all listings)",
+    },
+  },
+})

--- a/src/entities/Place/types.ts
+++ b/src/entities/Place/types.ts
@@ -78,6 +78,7 @@ export enum DisabledReason {
   OPT_OUT = "opt_out",
   UNDEPLOYMENT = "undeployment",
   OVERWRITTEN = "overwritten",
+  MODERATION = "moderation",
 }
 
 export enum PlaceListOrderBy {
@@ -144,4 +145,8 @@ export type UpdateRankingBody = {
 
 export type UpdateHighlightBody = {
   highlighted: boolean
+}
+
+export type UpdateDisabledBody = {
+  disabled: boolean
 }


### PR DESCRIPTION
## Why

When a scene is banned from the moderation center, the ban lands on the asset-bundle-registry denylist and propagates to catalysts — but the **Places record stays enabled**, so its title, description and thumbnail keep being served on the jump page (`decentraland.org/jump`), Places search, and the explorer's Discover tab. Example: parcel `-19,-111` still showed its banned scene's thumbnail after being denylisted, because `disabled` can only be set today by the deployment consumer (`opt_out` / `undeployment` / `overwritten`) and a denylist ban emits no deployment event.

## What

New admin endpoint, same auth pattern as rating/ranking/highlight (signed fetch + `ADMIN_ADDRESSES`):

```
PUT /places/:place_id/disable
Body: { "disabled": true | false }
```

- Disabling sets `disabled`, `disabled_at`, `disabled_reason = 'moderation'` and notifies Slack via the existing `notifyDisablePlaces` helper.
- Re-enabling clears `disabled_at` / `disabled_reason` — supports lifting a ban.
- New `DisabledReason.MODERATION` enum value. No migration needed: the column is already `varchar(20)` with no constraint.
- New `PlaceModel.updateDisabled` updates by id: the generic `updatePlace` can't be reused because its `WHERE` clause requires `disabled is false` for genesis places, which would make re-enabling a no-op.

## Notes

- The deployment consumer will still re-enable a place if a **new** scene is deployed on the same parcels — intentional, since a new deployment is a new entity that isn't covered by the entity-id ban anyway.
- Companion PR in `moderation-center` adds the UI action and hooks it into the scene-ban flow.

## Test

`npx jest src/entities/Place` — 131 tests pass, including 8 new ones for the endpoint (auth, not-found, disable, re-enable, Slack notification, validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)