### PR TITLE
feat: accept admin token on ranking endpoints

### DIFF
--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -68,7 +68,7 @@ The Decentraland Places service is a comprehensive API solution for discovering,
 
 The service exposes a REST API under `/api` with comprehensive documentation in [OpenAPI 3.0 format](openapi.yaml). Key endpoint categories:
 
-- **Places**: `/api/places`, `/api/places/:id`, `/api/places/status`, `/api/places/:id/categories`, `/api/places/:id/rating`, `/api/places/:id/ranking` (service token auth via `DATA_TEAM_AUTH_TOKEN` env var), `/api/places/:id/highlight` (admin only) (POST `/api/places` accepts array of place IDs in body)
+- **Places**: `/api/places`, `/api/places/:id`, `/api/places/status`, `/api/places/:id/categories`, `/api/places/:id/rating`, `/api/places/:id/ranking` (service token auth via `DATA_TEAM_AUTH_TOKEN` or `PLACES_ADMIN_AUTH_TOKEN` env vars), `/api/places/:id/highlight` (admin only) (POST `/api/places` accepts array of place IDs in body)
 - **Worlds**: `/api/worlds`, `/api/world_names`
 - **Destinations**: `/api/destinations` (GET: combined places + worlds with enhanced filtering including SDK version and LIKE name matching; highlighted items are always returned first, followed by ranking value, then by specified sort order. POST: accepts array of destination IDs in body, maximum 100 IDs per request, supports all GET query parameters for additional filtering)
 - **Map**: `/api/map`, `/api/map/places` (coordinate-based queries with higher limits)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -542,8 +542,8 @@ paths:
         Update the ranking score for a place. **Requires service token authentication.**
 
         This endpoint uses a pre-configured service token for authentication, intended for
-        service-to-service calls from the data team's systems. The token must be provided
-        in the Authorization header as `Bearer <token>` or just `<token>`.
+        service-to-service calls from the data team's systems or the places admin tooling. The token
+        must be provided in the Authorization header as `Bearer <token>` or just `<token>`.
 
         The ranking value is used to order places in listings. Higher ranking values appear first
         (after highlighted places). This endpoint is intended for the data team to curate
@@ -555,8 +555,8 @@ paths:
         - Set custom ordering for promotional periods
 
         **Authentication:**
-        Set the `DATA_TEAM_AUTH_TOKEN` environment variable on the server, then use that
-        token value in the Authorization header when calling this endpoint.
+        Accepts the value of either the `DATA_TEAM_AUTH_TOKEN` or the
+        `PLACES_ADMIN_AUTH_TOKEN` environment variable in the Authorization header.
       operationId: updatePlaceRanking
       parameters:
         - name: place_id
@@ -1746,8 +1746,9 @@ components:
         Pre-configured service token for service-to-service authentication.
 
         This authentication method is used for internal service calls, such as
-        the data team's ranking updates. The token value must match the
-        `DATA_TEAM_AUTH_TOKEN` environment variable configured on the server.
+        the data team's ranking updates. The token value must match either the
+        `DATA_TEAM_AUTH_TOKEN` or the `PLACES_ADMIN_AUTH_TOKEN` environment
+        variable configured on the server.
 
         To authenticate:
         Include in requests: `Authorization: Bearer <service-token>` or `Authorization: <service-token>`

--- a/docs/postman-collection.json
+++ b/docs/postman-collection.json
@@ -2,7 +2,7 @@
   "info": {
     "_postman_id": "places-api-collection",
     "name": "Decentraland Places API",
-    "description": "Backend HTTP API for the Decentraland Places service. Endpoints for place / world discovery, favorites, likes, ratings, admin actions and social/og metadata.\n\n## Environments\n\n- Production: `https://places.decentraland.org`\n- Staging: `https://places.decentraland.today`\n- Dev: `https://places.decentraland.zone`\n- Local: `http://localhost:4000`\n\nSet `{{base_url}}` accordingly.\n\n## Authentication\n\nThree different mechanisms are used by this API:\n\n1. **Decentraland auth-chain** — the standard wallet-signed identity. The collection variable `{{auth_token}}` is intended to hold a Bearer token compatible with `decentraland-gatsby` `withAuth*` middleware (or you can override the request to set `x-identity-*` headers manually). Required for endpoints that act on behalf of a user (favorites, likes, reports) or admin endpoints.\n2. **`PLACES_ADMIN_AUTH_TOKEN`** — opaque bearer token for the `featured` admin endpoints. Stored in `{{admin_auth_token}}`.\n3. **`DATA_TEAM_AUTH_TOKEN`** — opaque bearer token for the `ranking` endpoints. Stored in `{{data_team_auth_token}}`.\n\nThe collection sends the auth-chain token as `Authorization: Bearer` by default. Each request that needs a different token overrides its own `auth` block.\n\n## Conventions\n\n- `place_id` is a UUID v4.\n- `world_id` is the lowercased world name (e.g. `myworld.dcl.eth`).\n- `entity_id` is one of the two — the `/places/:entity_id/{favorites,likes}` endpoints accept both for backward compatibility.\n",
+    "description": "Backend HTTP API for the Decentraland Places service. Endpoints for place / world discovery, favorites, likes, ratings, admin actions and social/og metadata.\n\n## Environments\n\n- Production: `https://places.decentraland.org`\n- Staging: `https://places.decentraland.today`\n- Dev: `https://places.decentraland.zone`\n- Local: `http://localhost:4000`\n\nSet `{{base_url}}` accordingly.\n\n## Authentication\n\nThree different mechanisms are used by this API:\n\n1. **Decentraland auth-chain** — the standard wallet-signed identity. The collection variable `{{auth_token}}` is intended to hold a Bearer token compatible with `decentraland-gatsby` `withAuth*` middleware (or you can override the request to set `x-identity-*` headers manually). Required for endpoints that act on behalf of a user (favorites, likes, reports) or admin endpoints.\n2. **`PLACES_ADMIN_AUTH_TOKEN`** — opaque bearer token for the `featured` admin endpoints. Stored in `{{admin_auth_token}}`.\n3. **`DATA_TEAM_AUTH_TOKEN`** — opaque bearer token for the `ranking` endpoints (`PLACES_ADMIN_AUTH_TOKEN` is also accepted on them). Stored in `{{data_team_auth_token}}`.\n\nThe collection sends the auth-chain token as `Authorization: Bearer` by default. Each request that needs a different token overrides its own `auth` block.\n\n## Conventions\n\n- `place_id` is a UUID v4.\n- `world_id` is the lowercased world name (e.g. `myworld.dcl.eth`).\n- `entity_id` is one of the two — the `/places/:entity_id/{favorites,likes}` endpoints accept both for backward compatibility.\n",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "variable": [
@@ -27,7 +27,7 @@
     {
       "key": "data_team_auth_token",
       "value": "",
-      "description": "DATA_TEAM_AUTH_TOKEN — bearer token for `/ranking` endpoints.",
+      "description": "DATA_TEAM_AUTH_TOKEN — bearer token for `/ranking` endpoints (PLACES_ADMIN_AUTH_TOKEN also accepted).",
       "type": "string"
     },
     {
@@ -349,7 +349,7 @@
               "host": ["{{base_url}}"],
               "path": ["api", "places", "{{place_id}}", "ranking"]
             },
-            "description": "Sets the manual ranking score (higher values surface first). Body: `{ ranking: number | null }`. Authorized via `DATA_TEAM_AUTH_TOKEN` Bearer."
+            "description": "Sets the manual ranking score (higher values surface first). Body: `{ ranking: number | null }`. Authorized via `DATA_TEAM_AUTH_TOKEN` or `PLACES_ADMIN_AUTH_TOKEN` Bearer."
           }
         },
         {
@@ -572,7 +572,7 @@
               "host": ["{{base_url}}"],
               "path": ["api", "worlds", "{{world_id}}", "ranking"]
             },
-            "description": "Sets manual ranking for a world. Body: `{ ranking: number | null }`. Authorized via `DATA_TEAM_AUTH_TOKEN`."
+            "description": "Sets manual ranking for a world. Body: `{ ranking: number | null }`. Authorized via `DATA_TEAM_AUTH_TOKEN` or `PLACES_ADMIN_AUTH_TOKEN`."
           }
         },
         {

--- a/src/entities/Place/routes/updateRanking.test.ts
+++ b/src/entities/Place/routes/updateRanking.test.ts
@@ -7,15 +7,20 @@ import PlaceModel from "../model"
 import { updateRanking } from "./updateRanking"
 
 const VALID_TOKEN = "test-service-token-12345"
+const ADMIN_TOKEN = "test-admin-token-67890"
 const place_id = randomUUID()
 
-let mockEnvToken: string | undefined = VALID_TOKEN
+let mockDataTeamToken: string | undefined = VALID_TOKEN
+let mockAdminToken: string | undefined = ADMIN_TOKEN
 
 // Mock the env module
 jest.mock("decentraland-gatsby/dist/utils/env", () => {
   return jest.fn((key: string, defaultValue?: string) => {
     if (key === "DATA_TEAM_AUTH_TOKEN") {
-      return mockEnvToken ?? defaultValue
+      return mockDataTeamToken ?? defaultValue
+    }
+    if (key === "PLACES_ADMIN_AUTH_TOKEN") {
+      return mockAdminToken ?? defaultValue
     }
     return defaultValue
   })
@@ -25,7 +30,8 @@ const findByIdWithAggregates = jest.spyOn(PlaceModel, "findByIdWithAggregates")
 const updatePlace = jest.spyOn(PlaceModel, "updatePlace")
 
 beforeEach(() => {
-  mockEnvToken = VALID_TOKEN
+  mockDataTeamToken = VALID_TOKEN
+  mockAdminToken = ADMIN_TOKEN
 })
 
 afterEach(() => {
@@ -64,8 +70,9 @@ describe("updateRanking", () => {
       ).rejects.toThrow("Invalid Bearer Token")
     })
 
-    test("should return error when DATA_TEAM_AUTH_TOKEN is not configured", async () => {
-      mockEnvToken = ""
+    test("should return error when no ranking token is configured", async () => {
+      mockDataTeamToken = ""
+      mockAdminToken = ""
 
       const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
@@ -89,6 +96,47 @@ describe("updateRanking", () => {
 
       const request = new Request("http://0.0.0.0/")
       request.headers.set("Authorization", `Bearer ${VALID_TOKEN}`)
+      const url = new URL("https://localhost/")
+
+      const response = await updateRanking({
+        request,
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        body: { ranking: 0.85 },
+        url,
+      } as any)
+
+      expect(response.body.ok).toBe(true)
+    })
+
+    test("should accept the places admin token", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce(
+        placeGenesisPlazaWithAggregatedAttributes
+      )
+      updatePlace.mockResolvedValueOnce([] as any)
+
+      const request = new Request("http://0.0.0.0/")
+      request.headers.set("Authorization", `Bearer ${ADMIN_TOKEN}`)
+      const url = new URL("https://localhost/")
+
+      const response = await updateRanking({
+        request,
+        params: { place_id: placeGenesisPlazaWithAggregatedAttributes.id },
+        body: { ranking: 0.85 },
+        url,
+      } as any)
+
+      expect(response.body.ok).toBe(true)
+    })
+
+    test("should accept the admin token when the data team token is not configured", async () => {
+      mockDataTeamToken = ""
+      findByIdWithAggregates.mockResolvedValueOnce(
+        placeGenesisPlazaWithAggregatedAttributes
+      )
+      updatePlace.mockResolvedValueOnce([] as any)
+
+      const request = new Request("http://0.0.0.0/")
+      request.headers.set("Authorization", `Bearer ${ADMIN_TOKEN}`)
       const url = new URL("https://localhost/")
 
       const response = await updateRanking({

--- a/src/entities/Place/routes/updateRanking.ts
+++ b/src/entities/Place/routes/updateRanking.ts
@@ -1,11 +1,10 @@
-import withBearerToken from "decentraland-gatsby/dist/entities/Auth/routes/withBearerToken"
 import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
 import ApiResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ApiResponse"
 import ErrorResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ErrorResponse"
 import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Response"
 import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
-import env from "decentraland-gatsby/dist/utils/env"
 
+import { requireRankingToken } from "../../shared/auth"
 import { createWkcValidator } from "../../shared/validate"
 import PlaceModel from "../model"
 import { getPlaceParamsSchema, updateRankingBodySchema } from "../schemas"
@@ -26,8 +25,7 @@ const validateUpdateRankingBody = createWkcValidator<UpdateRankingBody>(
 export async function updateRanking(
   ctx: Context<{ place_id: string }, "request" | "body" | "params">
 ): Promise<ApiResponse<AggregatePlaceAttributes, {}>> {
-  const token = env("DATA_TEAM_AUTH_TOKEN", "")
-  await withBearerToken({ tokens: token ? [token] : [], optional: false })(ctx)
+  await requireRankingToken(ctx)
 
   const params = await validateUpdateRankingParams(ctx.params)
   const body = await validateUpdateRankingBody(ctx.body)

--- a/src/entities/World/routes/updateWorldRanking.test.ts
+++ b/src/entities/World/routes/updateWorldRanking.test.ts
@@ -1,0 +1,154 @@
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+import { SceneContentRating } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
+
+import WorldModel from "../model"
+import { AggregateWorldAttributes } from "../types"
+import { updateWorldRanking } from "./updateWorldRanking"
+
+const DATA_TEAM_TOKEN = "test-data-team-token-12345"
+const ADMIN_TOKEN = "test-admin-token-67890"
+const world_id = "brai.dcl.eth"
+
+let mockDataTeamToken: string | undefined = DATA_TEAM_TOKEN
+let mockAdminToken: string | undefined = ADMIN_TOKEN
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "DATA_TEAM_AUTH_TOKEN") {
+      return mockDataTeamToken ?? defaultValue
+    }
+    if (key === "PLACES_ADMIN_AUTH_TOKEN") {
+      return mockAdminToken ?? defaultValue
+    }
+    return defaultValue
+  })
+})
+
+const baseAggregateWorld: AggregateWorldAttributes = {
+  id: world_id,
+  world_name: world_id,
+  title: "The house of dToxic",
+  description: null,
+  image: null,
+  owner: null,
+  content_rating: SceneContentRating.TEEN,
+  categories: [],
+  likes: 0,
+  dislikes: 0,
+  favorites: 0,
+  like_rate: 0.5,
+  like_score: 0,
+  created_at: new Date(),
+  updated_at: new Date(),
+  show_in_places: true,
+  single_player: false,
+  skybox_time: null,
+  is_private: false,
+  highlighted: false,
+  highlighted_image: null,
+  ranking: null,
+  user_like: false,
+  user_dislike: false,
+  user_favorite: false,
+  user_visits: 0,
+  world: true,
+  contact_name: null,
+  base_position: "0,0",
+  deployed_at: null,
+}
+
+const findByIdWithAggregates = jest.spyOn(WorldModel, "findByIdWithAggregates")
+const updateRankingSpy = jest.spyOn(WorldModel, "updateRanking")
+
+const buildRequest = (token?: string) => {
+  const request = new Request("http://0.0.0.0/", { method: "PUT" })
+  if (token !== undefined) {
+    request.headers.set("Authorization", `Bearer ${token}`)
+  }
+  return request
+}
+
+const buildUrl = () => new URL("https://localhost/")
+
+beforeEach(() => {
+  mockDataTeamToken = DATA_TEAM_TOKEN
+  mockAdminToken = ADMIN_TOKEN
+})
+
+afterEach(() => {
+  findByIdWithAggregates.mockReset()
+  updateRankingSpy.mockReset()
+})
+
+describe("updateWorldRanking", () => {
+  describe("authentication", () => {
+    test("should accept the data team token", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce(baseAggregateWorld)
+      updateRankingSpy.mockResolvedValueOnce(undefined)
+
+      const response = await updateWorldRanking({
+        request: buildRequest(DATA_TEAM_TOKEN),
+        params: { world_id },
+        body: { ranking: 0.85 },
+        url: buildUrl(),
+      } as any)
+
+      expect(response.body.ok).toBe(true)
+      expect(response.body.data.ranking).toBe(0.85)
+      expect(updateRankingSpy).toHaveBeenCalledWith(world_id, 0.85)
+    })
+
+    test("should accept the places admin token", async () => {
+      findByIdWithAggregates.mockResolvedValueOnce(baseAggregateWorld)
+      updateRankingSpy.mockResolvedValueOnce(undefined)
+
+      const response = await updateWorldRanking({
+        request: buildRequest(ADMIN_TOKEN),
+        params: { world_id },
+        body: { ranking: 0.85 },
+        url: buildUrl(),
+      } as any)
+
+      expect(response.body.ok).toBe(true)
+      expect(updateRankingSpy).toHaveBeenCalledWith(world_id, 0.85)
+    })
+
+    test("should reject an invalid token", async () => {
+      await expect(() =>
+        updateWorldRanking({
+          request: buildRequest("invalid-token"),
+          params: { world_id },
+          body: { ranking: 0.85 },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("Invalid Bearer Token")
+
+      expect(updateRankingSpy).not.toHaveBeenCalled()
+    })
+
+    test("should reject when authorization header is missing", async () => {
+      await expect(() =>
+        updateWorldRanking({
+          request: buildRequest(),
+          params: { world_id },
+          body: { ranking: 0.85 },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("Missing Authorization")
+    })
+
+    test("should reject when no ranking token is configured", async () => {
+      mockDataTeamToken = ""
+      mockAdminToken = ""
+
+      await expect(() =>
+        updateWorldRanking({
+          request: buildRequest(DATA_TEAM_TOKEN),
+          params: { world_id },
+          body: { ranking: 0.85 },
+          url: buildUrl(),
+        } as any)
+      ).rejects.toThrow("Invalid Bearer Token")
+    })
+  })
+})

--- a/src/entities/World/routes/updateWorldRanking.ts
+++ b/src/entities/World/routes/updateWorldRanking.ts
@@ -1,11 +1,10 @@
-import withBearerToken from "decentraland-gatsby/dist/entities/Auth/routes/withBearerToken"
 import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
 import ApiResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ApiResponse"
 import ErrorResponse from "decentraland-gatsby/dist/entities/Route/wkc/response/ErrorResponse"
 import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Response"
 import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
-import env from "decentraland-gatsby/dist/utils/env"
 
+import { requireRankingToken } from "../../shared/auth"
 import { createWkcValidator } from "../../shared/validate"
 import WorldModel from "../model"
 import {
@@ -29,8 +28,7 @@ const validateBody = createWkcValidator<UpdateWorldRankingBody>(
 export async function updateWorldRanking(
   ctx: Context<{ world_id: string }, "request" | "body" | "params">
 ): Promise<ApiResponse<AggregateWorldAttributes, {}>> {
-  const token = env("DATA_TEAM_AUTH_TOKEN", "")
-  await withBearerToken({ tokens: token ? [token] : [], optional: false })(ctx)
+  await requireRankingToken(ctx)
 
   const params = await validateParams(ctx.params)
   const body = await validateBody(ctx.body)

--- a/src/entities/shared/auth.test.ts
+++ b/src/entities/shared/auth.test.ts
@@ -1,0 +1,91 @@
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+
+import { requireRankingToken } from "./auth"
+
+const DATA_TEAM_TOKEN = "test-data-team-token-12345"
+const ADMIN_TOKEN = "test-admin-token-67890"
+
+let mockDataTeamToken: string | undefined = DATA_TEAM_TOKEN
+let mockAdminToken: string | undefined = ADMIN_TOKEN
+
+jest.mock("decentraland-gatsby/dist/utils/env", () => {
+  return jest.fn((key: string, defaultValue?: string) => {
+    if (key === "DATA_TEAM_AUTH_TOKEN") {
+      return mockDataTeamToken ?? defaultValue
+    }
+    if (key === "PLACES_ADMIN_AUTH_TOKEN") {
+      return mockAdminToken ?? defaultValue
+    }
+    return defaultValue
+  })
+})
+
+const buildCtx = (token?: string) => {
+  const request = new Request("http://0.0.0.0/")
+  if (token !== undefined) {
+    request.headers.set("Authorization", `Bearer ${token}`)
+  }
+  return { request }
+}
+
+beforeEach(() => {
+  mockDataTeamToken = DATA_TEAM_TOKEN
+  mockAdminToken = ADMIN_TOKEN
+})
+
+describe("requireRankingToken", () => {
+  test("should accept the data team token", async () => {
+    await expect(requireRankingToken(buildCtx(DATA_TEAM_TOKEN))).resolves.toBe(
+      DATA_TEAM_TOKEN
+    )
+  })
+
+  test("should accept the admin token", async () => {
+    await expect(requireRankingToken(buildCtx(ADMIN_TOKEN))).resolves.toBe(
+      ADMIN_TOKEN
+    )
+  })
+
+  test("should reject an invalid token", async () => {
+    await expect(() =>
+      requireRankingToken(buildCtx("other-token"))
+    ).rejects.toThrow("Invalid Bearer Token")
+  })
+
+  test("should reject when the authorization header is missing", async () => {
+    await expect(() => requireRankingToken(buildCtx())).rejects.toThrow(
+      "Missing Authorization"
+    )
+  })
+
+  test("should reject every token when neither env var is configured", async () => {
+    mockDataTeamToken = ""
+    mockAdminToken = ""
+
+    await expect(() =>
+      requireRankingToken(buildCtx(DATA_TEAM_TOKEN))
+    ).rejects.toThrow("Invalid Bearer Token")
+  })
+
+  test("should accept the admin token when the data team token is not configured", async () => {
+    mockDataTeamToken = ""
+
+    await expect(requireRankingToken(buildCtx(ADMIN_TOKEN))).resolves.toBe(
+      ADMIN_TOKEN
+    )
+  })
+
+  test("should accept the data team token when the admin token is not configured", async () => {
+    mockAdminToken = ""
+
+    await expect(requireRankingToken(buildCtx(DATA_TEAM_TOKEN))).resolves.toBe(
+      DATA_TEAM_TOKEN
+    )
+  })
+
+  test("should reject a blank bearer token", async () => {
+    await expect(() => requireRankingToken(buildCtx(""))).rejects.toThrow(
+      "Invalid Authorization"
+    )
+  })
+})

--- a/src/entities/shared/auth.ts
+++ b/src/entities/shared/auth.ts
@@ -1,0 +1,19 @@
+import withBearerToken from "decentraland-gatsby/dist/entities/Auth/routes/withBearerToken"
+import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
+import env from "decentraland-gatsby/dist/utils/env"
+
+/**
+ * Authorizes ranking write endpoints. Accepts the data team service token
+ * or the places admin token. Env vars are read per-request so an empty
+ * value never becomes a valid credential.
+ */
+export async function requireRankingToken(
+  ctx: Pick<Context, "request">
+): Promise<string> {
+  const tokens = [
+    env("DATA_TEAM_AUTH_TOKEN", ""),
+    env("PLACES_ADMIN_AUTH_TOKEN", ""),
+  ].filter(Boolean)
+
+  return withBearerToken({ tokens, optional: false })(ctx)
+}


### PR DESCRIPTION
The ranking endpoints (`PUT /places/:place_id/ranking` and `PUT /worlds/:world_id/ranking`) only accepted `DATA_TEAM_AUTH_TOKEN`, while the featured curation endpoints use `PLACES_ADMIN_AUTH_TOKEN`, so ordering featured content required provisioning a second credential.

- Extracts a shared `requireRankingToken` authorizer that accepts either token, reading env vars per-request so an empty/unconfigured value never becomes a valid credential
- Both ranking endpoints now authorize with `DATA_TEAM_AUTH_TOKEN` or `PLACES_ADMIN_AUTH_TOKEN`
- Updates the OpenAPI spec, Postman collection and agent-context docs

Verified with unit tests covering both tokens, invalid tokens, missing header and unconfigured env vars, plus lint and build.