### PR TITLE
fix: keep a single active place per world scene to preserve place id

### DIFF
--- a/src/entities/CheckScenes/task/taskRunnerSqs.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.ts
@@ -187,25 +187,66 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
 
       placesToProcess = { update: place, rating, disabled: [] }
     } else {
-      // 0 or 2+ overlapping → create a new place, disable all overlapping
-      const place = createPlaceFromContentEntityScene(
-        contentEntityScene,
-        {},
-        options
-      )
+      // 0 or 2+ overlapping. If one of the overlapping places shares this
+      // scene's base parcel, it is the same scene (reshaped to overlap its
+      // neighbors): update it in place so its id is preserved, and disable the
+      // rest. This also keeps a single active row per (world_id, base_position),
+      // which the places_active_world_scene_uniq index now enforces. Otherwise
+      // this is a genuinely new scene superseding the overlapping ones: create a
+      // new place and disable them all.
+      const positions = (contentEntityScene?.pointers || []).slice().sort()
+      const base = contentEntityScene.metadata.scene?.base || positions[0]
+      const sameBasePlace = base
+        ? overlappingPlaces.find((place) => place.base_position === base)
+        : undefined
 
-      placesToProcess = {
-        new: place,
-        rating: {
-          id: randomUUID(),
-          entity_id: place.id,
-          original_rating: null,
-          update_rating: place.content_rating,
-          moderator: null,
-          comment: null,
-          created_at: new Date(),
-        },
-        disabled: overlappingPlaces,
+      if (sameBasePlace) {
+        const place = createPlaceFromContentEntityScene(
+          contentEntityScene,
+          sameBasePlace,
+          options
+        )
+
+        let rating = null
+        if (place.content_rating !== sameBasePlace.content_rating) {
+          rating = {
+            id: randomUUID(),
+            entity_id: sameBasePlace.id,
+            original_rating: sameBasePlace.content_rating,
+            update_rating: place.content_rating,
+            moderator: null,
+            comment: null,
+            created_at: new Date(),
+          }
+        }
+
+        placesToProcess = {
+          update: place,
+          rating,
+          disabled: overlappingPlaces.filter(
+            (place) => place.id !== sameBasePlace.id
+          ),
+        }
+      } else {
+        const place = createPlaceFromContentEntityScene(
+          contentEntityScene,
+          {},
+          options
+        )
+
+        placesToProcess = {
+          new: place,
+          rating: {
+            id: randomUUID(),
+            entity_id: place.id,
+            original_rating: null,
+            update_rating: place.content_rating,
+            moderator: null,
+            comment: null,
+            created_at: new Date(),
+          },
+          disabled: overlappingPlaces,
+        }
       }
     }
 

--- a/src/entities/CheckScenes/task/taskRunnerSqs.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.ts
@@ -31,7 +31,7 @@ import {
 } from "./processContentEntityScene"
 import { processEntityId } from "./processEntityId"
 
-const placesAttributes: Array<keyof PlaceAttributes> = [
+export const placesAttributes: Array<keyof PlaceAttributes> = [
   "title",
   "description",
   "image",

--- a/src/migrations/1784295151000_guard-active-world-place-uniqueness.ts
+++ b/src/migrations/1784295151000_guard-active-world-place-uniqueness.ts
@@ -1,0 +1,54 @@
+import { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate"
+
+export const shorthands: ColumnDefinitions | undefined = undefined
+
+export async function up(pgm: MigrationBuilder): Promise<void> {
+  // A world scene is uniquely identified by its (world_id, base_position). The
+  // deployment consumer resolves "same scene" by counting active overlapping
+  // rows, and an unguarded check-then-insert (plus SQS at-least-once delivery)
+  // could leave two ACTIVE rows for the same scene, each with a different id.
+  // From then on every deploy sees 2 overlaps and mints yet another id, which
+  // orphans anything keyed on the previous place id (e.g. env vars).
+  //
+  // Deduplicate before adding the unique index: for each (world_id, base_position)
+  // keep the most recently deployed active row and disable the rest. Ties are
+  // broken by id so the choice is deterministic.
+  pgm.sql(`
+    UPDATE places p
+    SET "disabled" = TRUE,
+        "disabled_at" = now(),
+        "updated_at" = now(),
+        "disabled_reason" = 'overwritten'
+    WHERE p.world IS TRUE
+      AND p.disabled IS FALSE
+      AND p.world_id IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM places q
+        WHERE q.world IS TRUE
+          AND q.disabled IS FALSE
+          AND q.world_id = p.world_id
+          AND q.base_position = p.base_position
+          AND (
+            q.deployed_at > p.deployed_at
+            OR (q.deployed_at = p.deployed_at AND q.id > p.id)
+          )
+      )
+  `)
+
+  // Structurally forbid two active rows for the same world scene. This makes the
+  // check-then-insert race impossible: the losing concurrent insert fails instead
+  // of silently creating a divergent id.
+  pgm.createIndex("places", ["world_id", "base_position"], {
+    name: "places_active_world_scene_uniq",
+    unique: true,
+    where: "world IS TRUE AND disabled IS FALSE AND world_id IS NOT NULL",
+  })
+}
+
+export async function down(pgm: MigrationBuilder): Promise<void> {
+  // Only the index is reversible; rows disabled by the dedup step above are left
+  // as-is (re-enabling them would recreate the duplicates this migration removed).
+  pgm.dropIndex("places", ["world_id", "base_position"], {
+    name: "places_active_world_scene_uniq",
+  })
+}

--- a/src/migrations/1784295151000_guard-active-world-place-uniqueness.ts
+++ b/src/migrations/1784295151000_guard-active-world-place-uniqueness.ts
@@ -2,52 +2,94 @@ import { ColumnDefinitions, MigrationBuilder } from "node-pg-migrate"
 
 export const shorthands: ColumnDefinitions | undefined = undefined
 
+// A world scene's identity is a row that is either enabled or opted out — the same
+// predicate `findActiveByWorldIdAndPositions` / the world `updatePlace` use to resolve
+// "same scene". An undeployed / overwritten / moderated row is NOT an identity. The
+// guard below must use exactly this predicate so it lines up with the application.
+const IDENTITY_PREDICATE = `
+  world IS TRUE
+  AND world_id IS NOT NULL
+  AND base_position IS NOT NULL
+  AND (disabled IS FALSE OR disabled_reason = 'opt_out')
+`
+
+// Canonical row for a (world_id, base_position): the one the rest of the system already
+// treats as primary. It mirrors the /api/places ordering (`like_score DESC NULLS LAST,
+// deployed_at DESC`) that world-storage-service resolves as `data[0]` when keying env vars,
+// preferring an enabled row over an opted-out one, with id as a deterministic final tiebreak.
+// Keeping this row (rather than blindly the newest) avoids stranding the id external data and
+// interactions are attached to.
+const CANONICAL_ORDER = `
+  (disabled IS FALSE) DESC,
+  like_score DESC NULLS LAST,
+  deployed_at DESC,
+  id DESC
+`
+
 export async function up(pgm: MigrationBuilder): Promise<void> {
-  // A world scene is uniquely identified by its (world_id, base_position). The
-  // deployment consumer resolves "same scene" by counting active overlapping
-  // rows, and an unguarded check-then-insert (plus SQS at-least-once delivery)
-  // could leave two ACTIVE rows for the same scene, each with a different id.
-  // From then on every deploy sees 2 overlaps and mints yet another id, which
-  // orphans anything keyed on the previous place id (e.g. env vars).
-  //
-  // Deduplicate before adding the unique index: for each (world_id, base_position)
-  // keep the most recently deployed active row and disable the rest. Ties are
-  // broken by id so the choice is deterministic.
+  // An unguarded check-then-insert (plus SQS at-least-once delivery) could leave two
+  // identity rows for the same world scene, each with a different id. From then on every
+  // deploy sees 2 overlaps and mints yet another id, orphaning anything keyed on the
+  // previous id (e.g. env vars in world-storage-service).
+
+  // Report every duplicate set and the id that will be retained, so the retained ids can be
+  // verified and any external references (env vars, etc.) reconciled from the migration log.
   pgm.sql(`
+    DO $$
+    DECLARE r RECORD;
+    BEGIN
+      FOR r IN
+        SELECT world_id,
+               base_position,
+               (ARRAY_AGG(id ORDER BY ${CANONICAL_ORDER}))[1] AS keep_id,
+               COUNT(*) AS total
+        FROM places
+        WHERE ${IDENTITY_PREDICATE}
+        GROUP BY world_id, base_position
+        HAVING COUNT(*) > 1
+      LOOP
+        RAISE NOTICE 'guard-active-world-place-uniqueness: world_id=% base_position=% keeping id=% disabling % duplicate(s)',
+          r.world_id, r.base_position, r.keep_id, r.total - 1;
+      END LOOP;
+    END $$;
+  `)
+
+  // Deduplicate: keep the canonical identity row per (world_id, base_position) and disable
+  // the rest. Required before the unique index below can be created.
+  pgm.sql(`
+    WITH ranked AS (
+      SELECT id,
+             ROW_NUMBER() OVER (
+               PARTITION BY world_id, base_position
+               ORDER BY ${CANONICAL_ORDER}
+             ) AS rn
+      FROM places
+      WHERE ${IDENTITY_PREDICATE}
+    )
     UPDATE places p
     SET "disabled" = TRUE,
         "disabled_at" = now(),
         "updated_at" = now(),
         "disabled_reason" = 'overwritten'
-    WHERE p.world IS TRUE
-      AND p.disabled IS FALSE
-      AND p.world_id IS NOT NULL
-      AND EXISTS (
-        SELECT 1 FROM places q
-        WHERE q.world IS TRUE
-          AND q.disabled IS FALSE
-          AND q.world_id = p.world_id
-          AND q.base_position = p.base_position
-          AND (
-            q.deployed_at > p.deployed_at
-            OR (q.deployed_at = p.deployed_at AND q.id > p.id)
-          )
-      )
+    FROM ranked r
+    WHERE p.id = r.id
+      AND r.rn > 1
   `)
 
-  // Structurally forbid two active rows for the same world scene. This makes the
-  // check-then-insert race impossible: the losing concurrent insert fails instead
-  // of silently creating a divergent id.
+  // Structurally forbid two identity rows for the same world scene. The predicate matches
+  // the application's active-identity predicate (enabled OR opt_out), so the check-then-insert
+  // race is impossible: the losing concurrent insert fails instead of creating a divergent id.
   pgm.createIndex("places", ["world_id", "base_position"], {
     name: "places_active_world_scene_uniq",
     unique: true,
-    where: "world IS TRUE AND disabled IS FALSE AND world_id IS NOT NULL",
+    where:
+      "world IS TRUE AND world_id IS NOT NULL AND base_position IS NOT NULL AND (disabled IS FALSE OR disabled_reason = 'opt_out')",
   })
 }
 
 export async function down(pgm: MigrationBuilder): Promise<void> {
-  // Only the index is reversible; rows disabled by the dedup step above are left
-  // as-is (re-enabling them would recreate the duplicates this migration removed).
+  // Only the index is reversible; rows disabled by the dedup step above are left as-is
+  // (re-enabling them would recreate the duplicates this migration removed).
   pgm.dropIndex("places", ["world_id", "base_position"], {
     name: "places_active_world_scene_uniq",
   })

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -1,10 +1,12 @@
 import { randomUUID } from "crypto"
 
+import database from "decentraland-gatsby/dist/entities/Database/database"
 import supertest from "supertest"
 
 import { DeploymentToSqs } from "../../src/entities/CheckScenes/task/consumer"
 import { extractSceneJsonData } from "../../src/entities/CheckScenes/task/extractSceneJsonData"
 import { handleWorldUndeployment } from "../../src/entities/CheckScenes/task/handleWorldUndeployment"
+import { createPlaceFromContentEntityScene } from "../../src/entities/CheckScenes/task/processContentEntityScene"
 import { processEntityId } from "../../src/entities/CheckScenes/task/processEntityId"
 import {
   placesAttributes,
@@ -856,6 +858,109 @@ describe("taskRunnerSqs integration", () => {
       await expect(
         PlaceModel.insertPlace(replacement, placesAttributes)
       ).resolves.not.toThrow()
+    })
+  })
+
+  describe("the active world place dedup step of the uniqueness migration", () => {
+    const UNIQUE_INDEX = "places_active_world_scene_uniq"
+
+    // Verbatim copy of the dedup step in
+    // src/migrations/1784295151000_guard-active-world-place-uniqueness.ts.
+    // That migration is immutable, so this snapshot cannot drift out from under it.
+    const DEDUP_SQL = `
+      UPDATE places p
+      SET "disabled" = TRUE,
+          "disabled_at" = now(),
+          "updated_at" = now(),
+          "disabled_reason" = 'overwritten'
+      WHERE p.world IS TRUE
+        AND p.disabled IS FALSE
+        AND p.world_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM places q
+          WHERE q.world IS TRUE
+            AND q.disabled IS FALSE
+            AND q.world_id = p.world_id
+            AND q.base_position = p.base_position
+            AND (
+              q.deployed_at > p.deployed_at
+              OR (q.deployed_at = p.deployed_at AND q.id > p.id)
+            )
+        )
+    `
+
+    const worldName = "dedup-world.dcl.eth"
+    let newestId: string
+    let olderIds: string[]
+
+    beforeEach(async () => {
+      // Reintroduce the pre-migration duplicate-active-row state (which the index
+      // now forbids) and feed it to the dedup step. All rows are inserted through
+      // the same path with hour-apart deployed_at values so their relative order
+      // survives however the naive timestamp column stores them.
+      await database.query(`DROP INDEX IF EXISTS "${UNIQUE_INDEX}"`)
+
+      const scene = createWorldContentEntityScene({
+        worldName,
+        base: "0,0",
+        parcels: ["0,0"],
+      })
+      const worldId = await WorldModel.insertWorldIfNotExists({
+        world_name: worldName,
+      })
+
+      const buildPlace = (title: string, deployedAt: Date) => ({
+        ...createPlaceFromContentEntityScene(scene, {}, { worldId }),
+        id: randomUUID(),
+        title,
+        deployed_at: deployedAt,
+      })
+
+      const baseMs = 1_700_000_000_000
+      const older = buildPlace("Older", new Date(baseMs))
+      const middle = buildPlace("Middle", new Date(baseMs + 3_600_000))
+      const newest = buildPlace("Newest", new Date(baseMs + 7_200_000))
+
+      await PlaceModel.insertPlace(older, placesAttributes)
+      await PlaceModel.insertPlace(middle, placesAttributes)
+      await PlaceModel.insertPlace(newest, placesAttributes)
+
+      newestId = newest.id
+      olderIds = [older.id, middle.id]
+
+      await database.query(DEDUP_SQL)
+    })
+
+    afterEach(async () => {
+      // Restore the index for the rest of the suite (dedup leaves a single active
+      // row, so the unique index can be recreated).
+      await database.query(
+        `CREATE UNIQUE INDEX IF NOT EXISTS "${UNIQUE_INDEX}" ON places ("world_id", "base_position") WHERE world IS TRUE AND disabled IS FALSE AND world_id IS NOT NULL`
+      )
+    })
+
+    it("should keep exactly one active place, the most recently deployed", async () => {
+      const active = (await PlaceModel.findByWorldId(worldName)).filter(
+        (place) => !place.disabled
+      )
+
+      expect(active).toHaveLength(1)
+      expect(active[0].id).toBe(newestId)
+    })
+
+    it("should disable the older duplicates with the overwritten reason", async () => {
+      const disabled = (await PlaceModel.findByWorldId(worldName)).filter(
+        (place) => place.disabled
+      )
+
+      expect(disabled.map((place) => place.id).sort()).toEqual(
+        [...olderIds].sort()
+      )
+      expect(
+        disabled.every(
+          (place) => place.disabled_reason === DisabledReason.OVERWRITTEN
+        )
+      ).toBe(true)
     })
   })
 

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -805,59 +805,109 @@ describe("taskRunnerSqs integration", () => {
   })
 
   describe("the active world scene uniqueness guard", () => {
-    let worldName: string
+    describe("and an enabled world scene already exists", () => {
+      const worldName = "uniqueness-guard-enabled.dcl.eth"
 
-    beforeEach(async () => {
-      worldName = "uniqueness-guard-world.dcl.eth"
+      beforeEach(async () => {
+        await deployWorldScene({
+          worldName,
+          title: "Only Scene",
+          base: "0,0",
+          parcels: ["0,0"],
+        })
+      })
 
-      await deployWorldScene({
-        worldName,
-        title: "Only Scene",
-        base: "0,0",
-        parcels: ["0,0"],
+      it("should reject a second enabled place for the same world scene", async () => {
+        const existing = await PlaceModel.findByWorldIdAndBasePosition(
+          worldName,
+          "0,0"
+        )
+        const duplicate = {
+          ...existing!,
+          id: randomUUID(),
+          created_at: new Date(),
+          updated_at: new Date(),
+        }
+
+        await expect(
+          PlaceModel.insertPlace(duplicate, placesAttributes)
+        ).rejects.toThrow()
+      })
+
+      it("should allow a new place once the original is disabled as overwritten", async () => {
+        const existing = await PlaceModel.findByWorldIdAndBasePosition(
+          worldName,
+          "0,0"
+        )
+        // overwritten/undeployment/moderation are not active identities, so the slot frees up
+        await PlaceModel.disablePlaces([existing!.id])
+
+        const replacement = {
+          ...existing!,
+          id: randomUUID(),
+          disabled: false,
+          disabled_at: null,
+          disabled_reason: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        }
+
+        await expect(
+          PlaceModel.insertPlace(replacement, placesAttributes)
+        ).resolves.not.toThrow()
       })
     })
 
-    it("should reject a second active place for the same world scene", async () => {
-      const existing = await PlaceModel.findByWorldIdAndBasePosition(
-        worldName,
-        "0,0"
-      )
+    describe("and an opted-out world scene already exists", () => {
+      const worldName = "uniqueness-guard-optout.dcl.eth"
 
-      // A second active row for the same (world_id, base_position) is exactly the
-      // divergent-id state the check-then-insert race used to produce.
-      const duplicate = {
-        ...existing!,
-        id: randomUUID(),
-        created_at: new Date(),
-        updated_at: new Date(),
-      }
+      beforeEach(async () => {
+        await deployWorldScene({
+          worldName,
+          title: "Opted Out",
+          base: "0,0",
+          parcels: ["0,0"],
+          optOut: true,
+        })
+      })
 
-      await expect(
-        PlaceModel.insertPlace(duplicate, placesAttributes)
-      ).rejects.toThrow()
-    })
+      it("should reject a second opted-out place for the same world scene", async () => {
+        const existing = await PlaceModel.findByWorldIdAndBasePosition(
+          worldName,
+          "0,0"
+        )
+        // opt_out rows are active identities too, so a duplicate must still be rejected
+        const duplicate = {
+          ...existing!,
+          id: randomUUID(),
+          created_at: new Date(),
+          updated_at: new Date(),
+        }
 
-    it("should allow a second row once the original is disabled", async () => {
-      const existing = await PlaceModel.findByWorldIdAndBasePosition(
-        worldName,
-        "0,0"
-      )
-      await PlaceModel.disablePlaces([existing!.id])
+        await expect(
+          PlaceModel.insertPlace(duplicate, placesAttributes)
+        ).rejects.toThrow()
+      })
 
-      const replacement = {
-        ...existing!,
-        id: randomUUID(),
-        disabled: false,
-        disabled_at: null,
-        disabled_reason: null,
-        created_at: new Date(),
-        updated_at: new Date(),
-      }
+      it("should reject an enabled place while an opted-out identity exists", async () => {
+        const existing = await PlaceModel.findByWorldIdAndBasePosition(
+          worldName,
+          "0,0"
+        )
+        const enabledDuplicate = {
+          ...existing!,
+          id: randomUUID(),
+          disabled: false,
+          disabled_at: null,
+          disabled_reason: null,
+          created_at: new Date(),
+          updated_at: new Date(),
+        }
 
-      await expect(
-        PlaceModel.insertPlace(replacement, placesAttributes)
-      ).resolves.not.toThrow()
+        await expect(
+          PlaceModel.insertPlace(enabledDuplicate, placesAttributes)
+        ).rejects.toThrow()
+      })
     })
   })
 
@@ -868,38 +918,46 @@ describe("taskRunnerSqs integration", () => {
     // src/migrations/1784295151000_guard-active-world-place-uniqueness.ts.
     // That migration is immutable, so this snapshot cannot drift out from under it.
     const DEDUP_SQL = `
+      WITH ranked AS (
+        SELECT id,
+               ROW_NUMBER() OVER (
+                 PARTITION BY world_id, base_position
+                 ORDER BY (disabled IS FALSE) DESC, like_score DESC NULLS LAST, deployed_at DESC, id DESC
+               ) AS rn
+        FROM places
+        WHERE world IS TRUE
+          AND world_id IS NOT NULL
+          AND base_position IS NOT NULL
+          AND (disabled IS FALSE OR disabled_reason = 'opt_out')
+      )
       UPDATE places p
       SET "disabled" = TRUE,
           "disabled_at" = now(),
           "updated_at" = now(),
           "disabled_reason" = 'overwritten'
-      WHERE p.world IS TRUE
-        AND p.disabled IS FALSE
-        AND p.world_id IS NOT NULL
-        AND EXISTS (
-          SELECT 1 FROM places q
-          WHERE q.world IS TRUE
-            AND q.disabled IS FALSE
-            AND q.world_id = p.world_id
-            AND q.base_position = p.base_position
-            AND (
-              q.deployed_at > p.deployed_at
-              OR (q.deployed_at = p.deployed_at AND q.id > p.id)
-            )
-        )
+      FROM ranked r
+      WHERE p.id = r.id
+        AND r.rn > 1
     `
 
-    const worldName = "dedup-world.dcl.eth"
-    let newestId: string
-    let olderIds: string[]
+    const RECREATE_INDEX_SQL = `
+      CREATE UNIQUE INDEX IF NOT EXISTS "${UNIQUE_INDEX}" ON places ("world_id", "base_position")
+      WHERE world IS TRUE AND world_id IS NOT NULL AND base_position IS NOT NULL
+        AND (disabled IS FALSE OR disabled_reason = 'opt_out')
+    `
 
-    beforeEach(async () => {
-      // Reintroduce the pre-migration duplicate-active-row state (which the index
-      // now forbids) and feed it to the dedup step. All rows are inserted through
-      // the same path with hour-apart deployed_at values so their relative order
-      // survives however the naive timestamp column stores them.
-      await database.query(`DROP INDEX IF EXISTS "${UNIQUE_INDEX}"`)
-
+    // Reintroduce the pre-migration duplicate-identity state (which the index now forbids)
+    // by inserting rows directly, then feed them to the dedup step. Rows are inserted through
+    // the same path so their relative deployed_at order survives the naive timestamp column.
+    const seedIdentityRows = async (
+      worldName: string,
+      rows: Array<{
+        title: string
+        deployedAt: Date
+        likeScore?: number
+        optOut?: boolean
+      }>
+    ): Promise<string[]> => {
       const scene = createWorldContentEntityScene({
         worldName,
         base: "0,0",
@@ -909,58 +967,159 @@ describe("taskRunnerSqs integration", () => {
         world_name: worldName,
       })
 
-      const buildPlace = (title: string, deployedAt: Date) => ({
-        ...createPlaceFromContentEntityScene(scene, {}, { worldId }),
-        id: randomUUID(),
-        title,
-        deployed_at: deployedAt,
-      })
+      const ids: string[] = []
+      for (const row of rows) {
+        const place = {
+          ...createPlaceFromContentEntityScene(scene, {}, { worldId }),
+          id: randomUUID(),
+          title: row.title,
+          deployed_at: row.deployedAt,
+          disabled: row.optOut ?? false,
+          disabled_reason: row.optOut ? DisabledReason.OPT_OUT : null,
+          disabled_at: row.optOut ? new Date() : null,
+        }
+        await PlaceModel.insertPlace(place, placesAttributes)
+        // like_score is not part of placesAttributes, so set it explicitly when needed.
+        if (row.likeScore !== undefined) {
+          await database.query(
+            `UPDATE places SET like_score = ${row.likeScore} WHERE id = '${place.id}'`
+          )
+        }
+        ids.push(place.id)
+      }
+      return ids
+    }
 
-      const baseMs = 1_700_000_000_000
-      const older = buildPlace("Older", new Date(baseMs))
-      const middle = buildPlace("Middle", new Date(baseMs + 3_600_000))
-      const newest = buildPlace("Newest", new Date(baseMs + 7_200_000))
-
-      await PlaceModel.insertPlace(older, placesAttributes)
-      await PlaceModel.insertPlace(middle, placesAttributes)
-      await PlaceModel.insertPlace(newest, placesAttributes)
-
-      newestId = newest.id
-      olderIds = [older.id, middle.id]
-
-      await database.query(DEDUP_SQL)
+    beforeEach(async () => {
+      await database.query(`DROP INDEX IF EXISTS "${UNIQUE_INDEX}"`)
     })
 
     afterEach(async () => {
-      // Restore the index for the rest of the suite (dedup leaves a single active
-      // row, so the unique index can be recreated).
-      await database.query(
-        `CREATE UNIQUE INDEX IF NOT EXISTS "${UNIQUE_INDEX}" ON places ("world_id", "base_position") WHERE world IS TRUE AND disabled IS FALSE AND world_id IS NOT NULL`
-      )
+      // Restore the index for the rest of the suite (dedup leaves a single identity
+      // row per scene, so the unique index can be recreated).
+      await database.query(RECREATE_INDEX_SQL)
     })
 
-    it("should keep exactly one active place, the most recently deployed", async () => {
-      const active = (await PlaceModel.findByWorldId(worldName)).filter(
-        (place) => !place.disabled
-      )
+    describe("and several enabled duplicates exist", () => {
+      const worldName = "dedup-enabled.dcl.eth"
+      const baseMs = 1_700_000_000_000
+      let newestId: string
+      let olderIds: string[]
 
-      expect(active).toHaveLength(1)
-      expect(active[0].id).toBe(newestId)
-    })
-
-    it("should disable the older duplicates with the overwritten reason", async () => {
-      const disabled = (await PlaceModel.findByWorldId(worldName)).filter(
-        (place) => place.disabled
-      )
-
-      expect(disabled.map((place) => place.id).sort()).toEqual(
-        [...olderIds].sort()
-      )
-      expect(
-        disabled.every(
-          (place) => place.disabled_reason === DisabledReason.OVERWRITTEN
+      beforeEach(async () => {
+        const [olderId, middleId, newestPlaceId] = await seedIdentityRows(
+          worldName,
+          [
+            { title: "Older", deployedAt: new Date(baseMs) },
+            { title: "Middle", deployedAt: new Date(baseMs + 3_600_000) },
+            { title: "Newest", deployedAt: new Date(baseMs + 7_200_000) },
+          ]
         )
-      ).toBe(true)
+        newestId = newestPlaceId
+        olderIds = [olderId, middleId]
+
+        await database.query(DEDUP_SQL)
+      })
+
+      it("should keep exactly one identity, the most recently deployed", async () => {
+        const active = (await PlaceModel.findByWorldId(worldName)).filter(
+          (place) => !place.disabled
+        )
+
+        expect(active).toHaveLength(1)
+        expect(active[0].id).toBe(newestId)
+      })
+
+      it("should disable the older duplicates with the overwritten reason", async () => {
+        const disabled = (await PlaceModel.findByWorldId(worldName)).filter(
+          (place) => place.disabled
+        )
+
+        expect(disabled.map((place) => place.id).sort()).toEqual(
+          [...olderIds].sort()
+        )
+        expect(
+          disabled.every(
+            (place) => place.disabled_reason === DisabledReason.OVERWRITTEN
+          )
+        ).toBe(true)
+      })
+    })
+
+    describe("and an older duplicate has more engagement than a newer one", () => {
+      const worldName = "dedup-engagement.dcl.eth"
+      const baseMs = 1_700_000_000_000
+      let engagedId: string
+
+      beforeEach(async () => {
+        const [olderEngagedId] = await seedIdentityRows(worldName, [
+          {
+            title: "Older but liked",
+            deployedAt: new Date(baseMs),
+            likeScore: 0.9,
+          },
+          {
+            title: "Newer but ignored",
+            deployedAt: new Date(baseMs + 7_200_000),
+            likeScore: 0.1,
+          },
+        ])
+        engagedId = olderEngagedId
+
+        await database.query(DEDUP_SQL)
+      })
+
+      it("should keep the higher-engagement place, not merely the newest", async () => {
+        const active = (await PlaceModel.findByWorldId(worldName)).filter(
+          (place) => !place.disabled
+        )
+
+        expect(active).toHaveLength(1)
+        expect(active[0].id).toBe(engagedId)
+      })
+    })
+
+    describe("and an enabled duplicate coexists with an opted-out one", () => {
+      const worldName = "dedup-optout.dcl.eth"
+      const baseMs = 1_700_000_000_000
+      let enabledId: string
+      let optOutId: string
+
+      beforeEach(async () => {
+        const [optOutPlaceId, enabledPlaceId] = await seedIdentityRows(
+          worldName,
+          [
+            {
+              title: "Opted out",
+              deployedAt: new Date(baseMs + 7_200_000),
+              optOut: true,
+            },
+            { title: "Enabled", deployedAt: new Date(baseMs) },
+          ]
+        )
+        optOutId = optOutPlaceId
+        enabledId = enabledPlaceId
+
+        await database.query(DEDUP_SQL)
+      })
+
+      it("should keep the enabled place as the identity", async () => {
+        const active = (await PlaceModel.findByWorldId(worldName)).filter(
+          (place) => !place.disabled
+        )
+
+        expect(active).toHaveLength(1)
+        expect(active[0].id).toBe(enabledId)
+      })
+
+      it("should disable the opted-out duplicate as overwritten", async () => {
+        const optOut = (await PlaceModel.findByWorldId(worldName)).find(
+          (place) => place.id === optOutId
+        )
+
+        expect(optOut!.disabled).toBe(true)
+        expect(optOut!.disabled_reason).toBe(DisabledReason.OVERWRITTEN)
+      })
     })
   })
 

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -730,6 +730,66 @@ describe("taskRunnerSqs integration", () => {
     })
   })
 
+  describe("when a new world scene overlaps multiple existing scenes and shares one of their base parcels", () => {
+    let worldName: string
+    let sceneAPlaceId: string
+    let sceneBPlaceId: string
+
+    beforeEach(async () => {
+      worldName = "multi-overlap-samebase-world.dcl.eth"
+
+      await deployWorldScene({
+        worldName,
+        title: "Scene A",
+        base: "0,0",
+        parcels: ["0,0", "0,1"],
+      })
+
+      await deployWorldScene({
+        worldName,
+        title: "Scene B",
+        base: "0,2",
+        parcels: ["0,2", "0,3"],
+      })
+
+      sceneAPlaceId = (await PlaceModel.findByWorldIdAndBasePosition(
+        worldName,
+        "0,0"
+      ))!.id
+      sceneBPlaceId = (await PlaceModel.findByWorldIdAndBasePosition(
+        worldName,
+        "0,2"
+      ))!.id
+
+      // Scene C overlaps both A (on 0,1) and B (on 0,2) but keeps Scene A's base (0,0)
+      await deployWorldScene({
+        worldName,
+        title: "Scene C",
+        base: "0,0",
+        parcels: ["0,0", "0,1", "0,2"],
+      })
+    })
+
+    it("should reuse the shared-base place id instead of creating a new one", async () => {
+      const enabledPlaces = await PlaceModel.findEnabledWorldName(worldName)
+
+      expect(enabledPlaces).toHaveLength(1)
+      expect(enabledPlaces[0].id).toBe(sceneAPlaceId)
+      expect(enabledPlaces[0].title).toBe("Scene C")
+    })
+
+    it("should disable only the other overlapping scene", async () => {
+      const sceneB = await PlaceModel.findByWorldIdAndBasePosition(
+        worldName,
+        "0,2"
+      )
+
+      expect(sceneB!.id).toBe(sceneBPlaceId)
+      expect(sceneB!.disabled).toBe(true)
+      expect(sceneB!.disabled_reason).toBe(DisabledReason.OVERWRITTEN)
+    })
+  })
+
   describe("when a newer world scene deployment already exists for overlapping positions", () => {
     let worldName: string
 

--- a/test/integration/taskRunnerSqs.test.ts
+++ b/test/integration/taskRunnerSqs.test.ts
@@ -1,10 +1,15 @@
+import { randomUUID } from "crypto"
+
 import supertest from "supertest"
 
 import { DeploymentToSqs } from "../../src/entities/CheckScenes/task/consumer"
 import { extractSceneJsonData } from "../../src/entities/CheckScenes/task/extractSceneJsonData"
 import { handleWorldUndeployment } from "../../src/entities/CheckScenes/task/handleWorldUndeployment"
 import { processEntityId } from "../../src/entities/CheckScenes/task/processEntityId"
-import { taskRunnerSqs } from "../../src/entities/CheckScenes/task/taskRunnerSqs"
+import {
+  placesAttributes,
+  taskRunnerSqs,
+} from "../../src/entities/CheckScenes/task/taskRunnerSqs"
 import { fetchNameOwner } from "../../src/entities/CheckScenes/utils"
 import PlaceModel from "../../src/entities/Place/model"
 import { DisabledReason } from "../../src/entities/Place/types"
@@ -778,6 +783,13 @@ describe("taskRunnerSqs integration", () => {
       expect(enabledPlaces[0].title).toBe("Scene C")
     })
 
+    it("should update the reused place with the redeployed positions", async () => {
+      const enabledPlaces = await PlaceModel.findEnabledWorldName(worldName)
+
+      expect(enabledPlaces[0].base_position).toBe("0,0")
+      expect(enabledPlaces[0].positions.sort()).toEqual(["0,0", "0,1", "0,2"])
+    })
+
     it("should disable only the other overlapping scene", async () => {
       const sceneB = await PlaceModel.findByWorldIdAndBasePosition(
         worldName,
@@ -787,6 +799,63 @@ describe("taskRunnerSqs integration", () => {
       expect(sceneB!.id).toBe(sceneBPlaceId)
       expect(sceneB!.disabled).toBe(true)
       expect(sceneB!.disabled_reason).toBe(DisabledReason.OVERWRITTEN)
+    })
+  })
+
+  describe("the active world scene uniqueness guard", () => {
+    let worldName: string
+
+    beforeEach(async () => {
+      worldName = "uniqueness-guard-world.dcl.eth"
+
+      await deployWorldScene({
+        worldName,
+        title: "Only Scene",
+        base: "0,0",
+        parcels: ["0,0"],
+      })
+    })
+
+    it("should reject a second active place for the same world scene", async () => {
+      const existing = await PlaceModel.findByWorldIdAndBasePosition(
+        worldName,
+        "0,0"
+      )
+
+      // A second active row for the same (world_id, base_position) is exactly the
+      // divergent-id state the check-then-insert race used to produce.
+      const duplicate = {
+        ...existing!,
+        id: randomUUID(),
+        created_at: new Date(),
+        updated_at: new Date(),
+      }
+
+      await expect(
+        PlaceModel.insertPlace(duplicate, placesAttributes)
+      ).rejects.toThrow()
+    })
+
+    it("should allow a second row once the original is disabled", async () => {
+      const existing = await PlaceModel.findByWorldIdAndBasePosition(
+        worldName,
+        "0,0"
+      )
+      await PlaceModel.disablePlaces([existing!.id])
+
+      const replacement = {
+        ...existing!,
+        id: randomUUID(),
+        disabled: false,
+        disabled_at: null,
+        disabled_reason: null,
+        created_at: new Date(),
+        updated_at: new Date(),
+      }
+
+      await expect(
+        PlaceModel.insertPlace(replacement, placesAttributes)
+      ).resolves.not.toThrow()
     })
   })
 


### PR DESCRIPTION
## Summary

A world scene is uniquely identified by its `(world_id, base_position)`. The deployment consumer resolves "same scene vs. new scene" by **counting active rows whose `positions` overlap the deploy's pointers** (`taskRunnerSqs.ts`): 1 overlap → update in place (id preserved); 0 or 2+ → insert a new place (new `randomUUID()`) and disable the overlaps.

Two problems let a world scene end up with a **new `place_id` when it shouldn't**, which orphans anything keyed on the previous id (e.g. env vars in world-storage-service):

1. **No uniqueness + unguarded check-then-insert.** Nothing at the DB level prevents two *active* rows for the same world scene (the only unique index is on the secondary `place_positions` table, which world places never touch). The `findActiveByWorldIdAndPositions → insertPlace` sequence has no lock/transaction, so under SQS at-least-once redelivery (a redelivery landing while the first is still processing) or an upstream double-publish, two inserts can both see 0 overlap and create two active rows with different ids. From then on every deploy sees 2 overlaps → mints yet another id.

2. **The 2+-overlap branch always minted a new id**, even when one of the overlapping rows is literally the same scene (same `base_position`), reshaped to touch a neighbor.

A world scene's **identity** is a row that is either enabled *or* opted out — the same predicate `findActiveByWorldIdAndPositions` and the world `updatePlace` use to resolve "same scene". Undeployed / overwritten / moderated rows are not identities. The guard aligns to exactly this predicate.

## Changes

**Migration `1784295151000_guard-active-world-place-uniqueness.ts`**
- Adds a **partial unique index** `places_active_world_scene_uniq` on `(world_id, base_position)` with predicate `world IS TRUE AND world_id IS NOT NULL AND base_position IS NOT NULL AND (disabled IS FALSE OR disabled_reason = 'opt_out')`. This matches the application's active-identity predicate (so opt-out duplicates are covered too), making the check-then-insert race impossible — the losing concurrent insert fails instead of creating a divergent id.
- **Deduplicates existing identity rows** before creating the index: for each `(world_id, base_position)` it keeps the **canonical** row and disables the rest (`disabled_reason='overwritten'`). Canonical mirrors the `/api/places` ordering the resolver uses — `(disabled IS FALSE) DESC, like_score DESC NULLS LAST, deployed_at DESC, id DESC` — so the retained id is exactly what world-storage-service resolves as `data[0]` (i.e. what env vars are keyed on), and it's the highest-engagement row, not merely the newest.
- **Reporting step**: a `DO`/`RAISE NOTICE` block logs each duplicate set with the retained id and the count being disabled, so retained ids can be verified and any external references (env vars) reconciled from the migration log.

**`taskRunnerSqs.ts` — identity-preserving overlap resolution**
- In the 0/2+ branch, if one of the overlapping active places shares this scene's `base_position`, that row is updated in place (id preserved) and the others are disabled — instead of unconditionally inserting a new place. This both preserves identity on a legitimate reshape-into-a-neighbor and guarantees the insert path is only taken when no active row holds the new base (so the new unique index never blocks a legitimate deploy — only the true race).

**`taskRunnerSqs.ts` — identity-preserving overlap resolution**
- In the 0/2+ branch, if one of the overlapping active places shares this scene's `base_position`, that row is updated in place (id preserved) and the others are disabled — instead of unconditionally inserting a new place. This both preserves identity on a legitimate reshape-into-a-neighbor and guarantees the insert path is only taken when no active row holds the new base (so the new unique index never blocks a legitimate deploy — only the true race).

## Behavior after this change

- Plain overwrite / reshape (1 overlap): update, **id preserved** — unchanged.
- Reshape that grows to overlap a neighbor, keeping the same base: now **id preserved** (was: new id).
- Genuinely new scene superseding others (no shared base): new id + disable overlaps — unchanged.
- Concurrent duplicate insert of a brand-new scene (enabled **or** opt-out): one wins, the other fails the unique index instead of creating a divergent identity row.
- Undeploy → redeploy: still a new id (a removed scene reappearing is a new place — intended). `opt_out` → redeploy still preserves the id.

## Testing

`test/integration/taskRunnerSqs.test.ts` — full file green (49/49; whole integration suite 217/217), run against a real Postgres with this migration applied:
- *"overlaps multiple existing scenes and shares one of their base parcels"* — the shared-base id is reused, the reused row picks up the redeployed positions, and only the other overlap is disabled.
- *"the active world scene uniqueness guard"* — a second **enabled** duplicate is rejected; a slot frees up once the original is disabled as `overwritten`; a second **opt-out** duplicate is rejected; and an enabled insert is rejected while an opt-out identity already exists.
- *"the active world place dedup step"* — drops the index, reintroduces duplicate identity rows, runs the migration's dedup SQL verbatim, and asserts: several enabled duplicates → newest kept + rest `overwritten`; an **older but higher-engagement** row is kept over a newer one; an **enabled** row is kept over an **opt-out** duplicate (which is disabled). Restores the index afterwards.
- Pre-existing cases still hold: "no shared base → new id + disable all", "reshaped → id preserved", "undeploy→redeploy → new id", "opt_out→redeploy → same id".

Migration applies cleanly (report + dedup + index) against a fresh `places_test`. `tsc` + eslint clean.

## Notes / trade-offs

- The dedup can only pick a single canonical per scene; if dependent data were ever split across duplicates (rare — the resolver has only ever surfaced `data[0]` to users), the `RAISE NOTICE` output surfaces the affected worlds for manual reconciliation. External env vars live in world-storage-service and can't be repointed from this migration, so the canonical is chosen to match what that service already resolves.
- On the rare true race, the losing insert raises a unique-violation, which the consumer logs via `notifyError` (message is still deleted, so no retry storm). A follow-up could use `ON CONFLICT DO NOTHING` on the world insert to silence it; kept out to stay minimal.
- The index is created non-`CONCURRENTLY` (matches the repo's other `pgm.createIndex` migrations); it briefly locks `places` on deploy. Say the word if you want a `CONCURRENTLY` variant (would need the migration marked non-transactional).
