### PR TITLE
fix: strip unsafe markup from place descriptions on ingestion

### DIFF
--- a/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
+++ b/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
@@ -6,7 +6,7 @@ import {
   isDowngradingRating,
   isUpgradingRating,
 } from "../../../utils/rating/contentRating"
-import { sanitizeImageUrl } from "../../Place/utils"
+import { sanitizeImageUrl, sanitizePlaceDescription } from "../../Place/utils"
 import {
   notifyDowngradeRating,
   notifyError,
@@ -74,7 +74,13 @@ export async function handleWorldSettingsChanged(
     await WorldModel.upsertWorld({
       world_name: worldName,
       title: event.metadata.title,
-      description: event.metadata.description,
+      // Preserve upsertWorld's "omitted means do not update" contract: only
+      // sanitize when a description was actually provided (worlds render in
+      // the same TMP client UI, so the same markup rules apply).
+      description:
+        event.metadata.description === undefined
+          ? undefined
+          : sanitizePlaceDescription(event.metadata.description),
       content_rating: contentRatingToUse,
       categories: event.metadata.categories,
       // Preserve upsertWorld's "omitted means do not update" contract: only

--- a/src/entities/CheckScenes/task/processContentEntityScene.test.ts
+++ b/src/entities/CheckScenes/task/processContentEntityScene.test.ts
@@ -1,4 +1,5 @@
 import { SQLStatement } from "decentraland-gatsby/dist/entities/Database/utils"
+import { ContentEntityScene } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 
 import {
   createPlaceFromContentEntityScene,
@@ -21,6 +22,30 @@ describe("createPlaceFromContentEntityScene", () => {
       updated_at: contentEntityDeployment.updated_at,
       created_at: contentEntityDeployment.created_at,
       textsearch: expect.any(SQLStatement),
+    })
+  })
+
+  describe("when the scene description contains client-rendered markup", () => {
+    let contentEntityScene: ContentEntityScene
+    let result: ReturnType<typeof createPlaceFromContentEntityScene>
+
+    beforeEach(() => {
+      contentEntityScene = {
+        ...contentEntitySceneGenesisPlaza,
+        metadata: {
+          ...contentEntitySceneGenesisPlaza.metadata,
+          display: {
+            ...contentEntitySceneGenesisPlaza.metadata?.display,
+            description:
+              'Join us <link="decentraland://?position=0,0">click here</link>',
+          },
+        },
+      } as ContentEntityScene
+      result = createPlaceFromContentEntityScene(contentEntityScene)
+    })
+
+    it("should strip the markup so it cannot be rendered as a live tag", () => {
+      expect(result.description).toBe("Join us click here")
     })
   })
 

--- a/src/entities/CheckScenes/task/processContentEntityScene.ts
+++ b/src/entities/CheckScenes/task/processContentEntityScene.ts
@@ -11,7 +11,10 @@ import getContentRating, {
 } from "../../../utils/rating/contentRating"
 import PlaceModel from "../../Place/model"
 import { PlaceAttributes } from "../../Place/types"
-import { getThumbnailFromContentDeployment as getThumbnailFromContentEntityScene } from "../../Place/utils"
+import {
+  getThumbnailFromContentDeployment as getThumbnailFromContentEntityScene,
+  sanitizePlaceDescription,
+} from "../../Place/utils"
 import { PlaceContentRatingAttributes } from "../../PlaceContentRating/types"
 import { notifyDowngradeRating, notifyUpgradingRating } from "../../Slack/utils"
 import { findNewDeployedPlace, findSamePlace } from "../utils"
@@ -156,7 +159,17 @@ export function createPlaceFromContentEntityScene(
     world_id: options.worldId || null,
     ...data,
     title: title ? title.slice(0, 50) : "Untitled",
-    description: contentEntityScene?.metadata?.display?.description || null,
+    // Strip markup from the creator-authored description before storing so
+    // TMP tags like `<link="decentraland://…">` / `smb://` / `file://`
+    // that the Unity client renders (and opens on click, unprompted) are
+    // neutralized at rest, covering every read path uniformly. Stripping
+    // rather than html-escaping keeps the text clean, since the client is
+    // TextMeshPro (which does not decode HTML entities), not an HTML
+    // renderer. The social/OG HTML path keeps its own escape() in
+    // Social/routes.ts.
+    description: sanitizePlaceDescription(
+      contentEntityScene?.metadata?.display?.description
+    ),
     owner: contentEntityScene?.metadata?.owner || null,
     image: thumbnail,
     base_position: contentEntityScene?.metadata?.scene?.base || positions[0],

--- a/src/entities/CheckScenes/task/taskRunnerSqs.ts
+++ b/src/entities/CheckScenes/task/taskRunnerSqs.ts
@@ -6,6 +6,7 @@ import CategoryModel from "../../Category/model"
 import { DecentralandCategories } from "../../Category/types"
 import PlaceModel from "../../Place/model"
 import { DisabledReason, PlaceAttributes } from "../../Place/types"
+import { sanitizePlaceDescription } from "../../Place/utils"
 import PlaceCategories from "../../PlaceCategories/model"
 import PlaceContentRatingModel from "../../PlaceContentRating/model"
 import PlacePositionModel from "../../PlacePosition/model"
@@ -120,7 +121,9 @@ export async function taskRunnerSqs(job: DeploymentToSqs) {
       title:
         contentEntityScene?.metadata?.display?.title?.slice(0, 50) || undefined,
       description:
-        contentEntityScene?.metadata?.display?.description || undefined,
+        sanitizePlaceDescription(
+          contentEntityScene?.metadata?.display?.description
+        ) || undefined,
       content_rating:
         (contentEntityScene?.metadata?.policy
           ?.contentRating as SceneContentRating) || undefined,

--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -6,6 +6,7 @@ import {
   placesWithUserCount,
   placesWithUserVisits,
   sanitizeImageUrl,
+  sanitizePlaceDescription,
   siteUrl,
   whatsOnPlaceUrl,
   whatsOnWorldUrl,
@@ -296,5 +297,194 @@ describe("get of AggregatePlaceAttributes", () => {
         realms_detail: hotSceneGenesisPlaza.realms,
       },
     ])
+  })
+})
+
+describe("sanitizePlaceDescription", () => {
+  describe("when the description embeds a TMP <link> tag to a custom protocol", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        'Join <link="decentraland://?position=0,0">click here</link>'
+      )
+    })
+
+    it("should strip both sides of the unsafe link and keep the inner text", () => {
+      expect(result).toBe("Join click here")
+    })
+  })
+
+  describe("when the description embeds a <link> tag to a file/smb target", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        'a <link="file:///etc/passwd">x</link> b <link="smb://h/s">y</link> c'
+      )
+    })
+
+    it("should strip every unsafe link without leaving orphan tags", () => {
+      expect(result).toBe("a x b y c")
+    })
+  })
+
+  describe("when the description embeds a safe https <link> tag", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        'Visit <link="https://decentraland.org">our site</link>'
+      )
+    })
+
+    it("should preserve the link tag untouched", () => {
+      expect(result).toBe(
+        'Visit <link="https://decentraland.org">our site</link>'
+      )
+    })
+  })
+
+  describe("when the description embeds a safe http <link> tag", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription('<link="http://example.com">x</link>')
+    })
+
+    it("should preserve the link tag untouched", () => {
+      expect(result).toBe('<link="http://example.com">x</link>')
+    })
+  })
+
+  describe("when the description mixes a safe and an unsafe link", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        '<link="https://a.com">A</link><link="javascript:alert(1)">B</link>'
+      )
+    })
+
+    it("should keep the safe link and strip the unsafe one", () => {
+      expect(result).toBe('<link="https://a.com">A</link>B')
+    })
+  })
+
+  describe("when a link tag carries extra content after the target", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        "<link=https://a.com onclick=x>t</link>"
+      )
+    })
+
+    it("should strip the ambiguous tag (fail-safe)", () => {
+      expect(result).toBe("t")
+    })
+  })
+
+  describe("when a link points at the cloud-metadata IP", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        '<link="http://169.254.169.254/latest/meta-data/">x</link>'
+      )
+    })
+
+    it("should strip it", () => {
+      expect(result).toBe("x")
+    })
+  })
+
+  describe("when a link points at an obfuscated loopback IP", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      // 2130706433 === 127.0.0.1; the URL parser normalizes it before the check.
+      result = sanitizePlaceDescription('<link="http://2130706433/">x</link>')
+    })
+
+    it("should strip it", () => {
+      expect(result).toBe("x")
+    })
+  })
+
+  describe("when a link points at a private or localhost host", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        'a <link="http://192.168.1.1/">x</link> b <link="http://localhost:8080/">y</link> c'
+      )
+    })
+
+    it("should strip both internal links", () => {
+      expect(result).toBe("a x b y c")
+    })
+  })
+
+  describe("when a link points at a public host", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription('<link="https://8.8.8.8/">x</link>')
+    })
+
+    it("should keep it", () => {
+      expect(result).toBe('<link="https://8.8.8.8/">x</link>')
+    })
+  })
+
+  describe("when a link points at a single-label or reserved-suffix host", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        'a <link="http://router/">x</link> b <link="http://printer.lan/">y</link> c <link="http://nas.local/">z</link> d'
+      )
+    })
+
+    it("should strip these local-looking hosts", () => {
+      expect(result).toBe("a x b y c z d")
+    })
+  })
+
+  describe("when the description contains prose with comparison operators", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription("Open 5 < 10 hours & counting")
+    })
+
+    it("should leave non-tag angle brackets and ampersands untouched", () => {
+      expect(result).toBe("Open 5 < 10 hours & counting")
+    })
+  })
+
+  describe("when the description is null", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(null)
+    })
+
+    it("should return null", () => {
+      expect(result).toBeNull()
+    })
+  })
+
+  describe("when the description is an empty string", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription("")
+    })
+
+    it("should normalize it to null", () => {
+      expect(result).toBeNull()
+    })
   })
 })

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -259,3 +259,149 @@ export function placesWithLastUpdate(
     }
   })
 }
+
+// Matches an HTML-/TMP-style markup tag: `<` followed by an optional
+// closing slash and a tag name that begins with a letter, up to the next
+// `>` (`<link="…">`, `</link>`, `<b>`, `<color=#fff>`). A bare `<` in
+// prose ("5 < 10") is left untouched because it isn't immediately
+// followed by a letter or slash.
+const MARKUP_TAG_REGEX = /<\/?[a-zA-Z][^<>]*>/g
+
+// A TMP `<link=…>` / `<link="…">` opening tag, capturing the (optionally
+// quoted) target, and its matching `</link>` closing tag. The opening
+// pattern only matches a *clean* single-value link tag — any extra
+// attributes or stray quotes make it fall through to the strip branch, so
+// ambiguous tags are never preserved (fail-safe).
+const LINK_OPEN_TAG_REGEX = /^<link\s*=\s*"?([^"<>]*)"?\s*>$/i
+const LINK_CLOSE_TAG_REGEX = /^<\/link\s*>$/i
+
+// Hosts a link must never point at: loopback, private, link-local (incl.
+// the `169.254.169.254` cloud-metadata endpoint), carrier-grade NAT, and
+// internal/`localhost` names. `hostname` is already lowercased and
+// WHATWG-normalized by `new URL`, so obfuscated IPv4 forms (decimal, hex,
+// octal, short) arrive here as canonical dotted quads and can't slip past.
+// Reserved / internal-use DNS suffixes that never belong to a public host.
+const INTERNAL_HOST_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".intranet",
+  ".lan",
+  ".home",
+  ".corp",
+  ".home.arpa",
+]
+
+function isInternalLinkHost(hostname: string): boolean {
+  const host =
+    hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname
+
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (ipv4) {
+    const a = Number(ipv4[1])
+    const b = Number(ipv4[2])
+    return (
+      a === 0 || // "this host"
+      a === 127 || // loopback
+      a === 10 || // private
+      (a === 169 && b === 254) || // link-local incl. cloud metadata
+      (a === 172 && b >= 16 && b <= 31) || // private
+      (a === 192 && b === 168) || // private
+      (a === 100 && b >= 64 && b <= 127) // carrier-grade NAT
+    )
+  }
+
+  if (host.includes(":")) {
+    return (
+      host === "::1" || // loopback
+      host === "::" || // unspecified
+      /^fe[89ab]/.test(host) || // link-local fe80::/10
+      /^f[cd]/.test(host) || // unique-local fc00::/7
+      host.startsWith("::ffff:") // IPv4-mapped
+    )
+  }
+
+  // DNS name. A public host is a dotted FQDN under a real TLD, so a
+  // single-label name (`router`, `nas`, `localhost`) or a reserved
+  // internal-use suffix is treated as internal. DNS is not resolved here —
+  // this is a best-effort fail-closed for local-looking names, not proof the
+  // host is public.
+  if (!host.includes(".")) {
+    return true
+  }
+  return INTERNAL_HOST_SUFFIXES.some((suffix) => host.endsWith(suffix))
+}
+
+// Only http(s) links to a public host are safe to hand to the client, which
+// renders descriptions as TextMeshPro rich text and passes a clicked
+// `<link>` target straight to an unrestricted `Application.OpenURL`. A
+// non-web scheme (`file://`, `smb://`, `decentraland://`, `javascript:`,
+// `data:`, …) fires a local handler on the viewer's machine, and an http(s)
+// URL aimed at an internal/loopback/metadata host points the viewer's
+// browser at their own network — so both are stripped.
+function isSafeLinkTarget(target: string): boolean {
+  const trimmed = target.trim()
+  // A real URL never carries raw whitespace, so an inner space means the
+  // tag had extra junk after the target (e.g. `<link=https://a onclick=x>`);
+  // treat it as ambiguous and strip it.
+  if (/\s/.test(trimmed)) {
+    return false
+  }
+
+  let url: URL
+  try {
+    url = new URL(trimmed)
+  } catch {
+    return false
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return false
+  }
+
+  return !isInternalLinkHost(url.hostname.toLowerCase())
+}
+
+/**
+ * Neutralize unsafe markup in a creator-authored description while
+ * preserving safe hyperlinks.
+ *
+ * The Unity client renders place descriptions with TextMeshPro rich text
+ * (no HTML, no Markdown) and turns `<link="target">text</link>` into a
+ * clickable link that reaches an unrestricted `Application.OpenURL(target)`
+ * — so a `decentraland://` / `smb://` / `file://` target fires a local
+ * handler on the viewer's machine. `<link>` tags pointing at http(s) URLs
+ * — the legitimate use case — are kept; links to any other scheme and
+ * every other markup tag are stripped (dropping both sides of a stripped
+ * link so no orphan `</link>` is left behind). Unlike html-escaping this
+ * leaves clean text, since TMP does not decode entities like `&lt;`.
+ * Returns null for empty input to match the column's `string | null` shape.
+ */
+export function sanitizePlaceDescription(
+  description: string | null | undefined
+): string | null {
+  if (!description) {
+    return null
+  }
+
+  // `replace` visits matches left-to-right, so a stack records whether the
+  // `<link>` currently being closed was kept, to decide its `</link>`.
+  const openLinkKept: boolean[] = []
+  return description.replace(MARKUP_TAG_REGEX, (tag) => {
+    if (LINK_CLOSE_TAG_REGEX.test(tag)) {
+      // Drop orphan closers; otherwise mirror the matching opener.
+      return openLinkKept.length > 0 && openLinkKept.pop() ? tag : ""
+    }
+
+    const openMatch = tag.match(LINK_OPEN_TAG_REGEX)
+    if (openMatch) {
+      const keep = isSafeLinkTarget(openMatch[1])
+      openLinkKept.push(keep)
+      return keep ? tag : ""
+    }
+
+    return ""
+  })
+}

--- a/test/integration/handleWorldSettingsChanged.test.ts
+++ b/test/integration/handleWorldSettingsChanged.test.ts
@@ -126,6 +126,33 @@ describe("handleWorldSettingsChanged integration", () => {
       })
     })
 
+    describe("and the description contains client-rendered markup", () => {
+      beforeEach(async () => {
+        const markupEvent = createWorldSettingsChangedEvent({
+          key: "existingworld.dcl.eth",
+          metadata: {
+            worldName: "existingworld.dcl.eth",
+            title: "Updated Title",
+            description:
+              'Join <link="decentraland://?position=0,0">here</link> and <link="https://decentraland.org">site</link>',
+            contentRating: "T",
+            categories: ["game"],
+          },
+        })
+        await handleWorldSettingsChanged(markupEvent)
+      })
+
+      it("should strip the unsafe link and keep the safe one", async () => {
+        const response = await supertest(app)
+          .get("/api/worlds/existingworld.dcl.eth")
+          .expect(200)
+
+        expect(response.body.data.description).toBe(
+          'Join here and <link="https://decentraland.org">site</link>'
+        )
+      })
+    })
+
     describe("and the rating is upgraded", () => {
       beforeEach(async () => {
         const upgradeEvent = createWorldSettingsUpgradeRatingEvent(


### PR DESCRIPTION
## what

the unity client renders place descriptions as textmeshpro rich text (no html, no markdown), so a stored `<link="decentraland://...">` / `smb://` / `file://` tag becomes a live, unprompted clickable link that reaches an unrestricted `Application.OpenURL` on the viewer's machine (see the client's security-audit items #7 / #22).

## changes

- new `sanitizePlaceDescription` in `Place/utils.ts` **keeps `<link>` tags pointing at http(s) URLs** (the legitimate use case — creators link out with custom anchor text) and strips links to any other scheme (`decentraland://`, `smb://`, `file://`, `javascript:`, `data:`, …) plus every other markup tag. both sides of a stripped link are removed so no orphan `</link>` remains; prose and non-tag characters (`5 < 10`, `&`) survive.
- matching is fail-safe: only a cleanly-parsed `<link=…>` whose target parses (via the WHATWG `URL`) as an `http(s)://` URL to a **public host** — no inner whitespace, and not a loopback / private / link-local (incl. the `169.254.169.254` cloud-metadata endpoint) / internal / `localhost` host — is kept; anything ambiguous is stripped. (obfuscated IPs like `http://2130706433/` are normalized by the parser before the host check, so they can't slip past.)
- rebased onto master to pick up #853 (social-image sanitize + gatsby 8.4.7); `Place/utils.ts` now hosts both `sanitizeImageUrl` and `sanitizePlaceDescription`.
- applied at ingestion in `processContentEntityScene`, so the stored value is safe and every read path (`getPlace`, `getPlaceList`, map, destinations, …) is covered uniformly.
- stripping rather than html-escaping keeps the text clean, since tmp does not decode entities like `&lt;` / `&#39;`. the social/og html path keeps its own `escape()` in `Social/routes.ts`, which is a genuine html surface consumed by link-preview crawlers.

note: existing rows are sanitized on their next deployment; a one-time backfill can be added if we want current rows covered immediately.

## testing

- `sanitizePlaceDescription` unit tests: safe http(s) link preservation, unsafe-scheme link + other-tag stripping, mixed safe/unsafe, ambiguous-tag fail-safe, prose/ampersand preservation, null and empty-string normalization.
- `processContentEntityScene` ingestion test asserts unsafe markup is stripped.
- description-adjacent suites green locally.

## related

part of a coordinated cross-repo change against client-rendered `<link>` markup:
- decentraland/events#986 — backend re-moderation + description strip
- decentraland/places#852 — this pr (place description strip at ingestion)
- decentraland/sites#688 — warn the owner when an approved-hangout edit needs re-review
