### PR TITLE
fix: reject non-http(s) scene and world thumbnails before storing them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dcl/schemas": "^25.0.0",
         "@well-known-components/pushable-channel": "^1.0.3",
         "aws-sdk": "^2.1002.0",
-        "decentraland-gatsby": "^8.4.6",
+        "decentraland-gatsby": "^8.4.7",
         "html-escaper": "^3.0.3",
         "node-pg-migrate": "^6.0.0",
         "pg": "^8.13.1",
@@ -22483,9 +22483,9 @@
       }
     },
     "node_modules/decentraland-gatsby": {
-      "version": "8.4.6",
-      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.6.tgz",
-      "integrity": "sha512-V72OrZzLWOvEY/GC4a3GZBAnN+Y/wlPVhdU6IS9W5KHC8aYcWwSpTybBsBV7GVoc9H/c92z8sVC43IauHkz6Sw==",
+      "version": "8.4.7",
+      "resolved": "https://registry.npmjs.org/decentraland-gatsby/-/decentraland-gatsby-8.4.7.tgz",
+      "integrity": "sha512-5SD+EjqYXy+aEZT3wtYHgPLNHMhvqEwltos4lAsawUAAcD3UatFzEXPkaEV899GL5FYmiDRY7yz2FTai3Z0Ixg==",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-ses": "^3.421.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@dcl/schemas": "^25.0.0",
     "@well-known-components/pushable-channel": "^1.0.3",
     "aws-sdk": "^2.1002.0",
-    "decentraland-gatsby": "^8.4.6",
+    "decentraland-gatsby": "^8.4.7",
     "html-escaper": "^3.0.3",
     "node-pg-migrate": "^6.0.0",
     "pg": "^8.13.1",

--- a/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
+++ b/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
@@ -6,6 +6,7 @@ import {
   isDowngradingRating,
   isUpgradingRating,
 } from "../../../utils/rating/contentRating"
+import { sanitizeImageUrl } from "../../Place/utils"
 import {
   notifyDowngradeRating,
   notifyError,
@@ -76,7 +77,7 @@ export async function handleWorldSettingsChanged(
       description: event.metadata.description,
       content_rating: contentRatingToUse,
       categories: event.metadata.categories,
-      image: event.metadata.thumbnailUrl,
+      image: sanitizeImageUrl(event.metadata.thumbnailUrl),
       show_in_places: event.metadata.showInPlaces,
       single_player: event.metadata.singlePlayer,
       skybox_time: event.metadata.skyboxTime,

--- a/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
+++ b/src/entities/CheckScenes/task/handleWorldSettingsChanged.ts
@@ -77,7 +77,13 @@ export async function handleWorldSettingsChanged(
       description: event.metadata.description,
       content_rating: contentRatingToUse,
       categories: event.metadata.categories,
-      image: sanitizeImageUrl(event.metadata.thumbnailUrl),
+      // Preserve upsertWorld's "omitted means do not update" contract: only
+      // convert to null when a thumbnail was actually provided but is unsafe, so
+      // a settings event without a thumbnailUrl never clears an existing image.
+      image:
+        event.metadata.thumbnailUrl === undefined
+          ? undefined
+          : sanitizeImageUrl(event.metadata.thumbnailUrl),
       show_in_places: event.metadata.showInPlaces,
       single_player: event.metadata.singlePlayer,
       skybox_time: event.metadata.skyboxTime,

--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -5,6 +5,7 @@ import {
   placeUrl,
   placesWithUserCount,
   placesWithUserVisits,
+  sanitizeImageUrl,
   siteUrl,
   whatsOnPlaceUrl,
   whatsOnWorldUrl,
@@ -130,6 +131,104 @@ describe("getThumbnail", () => {
     expect(url).toBe(
       "https://peer.decentraland.org/content/contents/bafkreidj26s7aenyxfthfdibnqonzqm5ptc4iamml744gmcyuokewkr76y"
     )
+  })
+})
+
+describe("sanitizeImageUrl", () => {
+  describe("when the value is a valid https url", () => {
+    let value: string
+
+    beforeEach(() => {
+      value = "https://cdn.decentraland.org/thumb.png"
+    })
+
+    it("should return the normalized url", () => {
+      expect(sanitizeImageUrl(value)).toBe(
+        "https://cdn.decentraland.org/thumb.png"
+      )
+    })
+  })
+
+  describe("when the value contains HTML-breakout characters", () => {
+    let value: string
+
+    beforeEach(() => {
+      value = `https://a"><meta http-equiv="refresh" content="0;url=https://example.com"><meta name="x`
+    })
+
+    it("should return null so the payload is never stored", () => {
+      expect(sanitizeImageUrl(value)).toBeNull()
+    })
+  })
+
+  describe("when the value uses a non-http(s) protocol", () => {
+    let value: string
+
+    beforeEach(() => {
+      value = "javascript:alert(document.domain)"
+    })
+
+    it("should return null", () => {
+      expect(sanitizeImageUrl(value)).toBeNull()
+    })
+  })
+
+  describe("when the value is undefined", () => {
+    let value: string | undefined
+
+    beforeEach(() => {
+      value = undefined
+    })
+
+    it("should return null", () => {
+      expect(sanitizeImageUrl(value)).toBeNull()
+    })
+  })
+})
+
+describe("getThumbnailFromContentDeployment breakout handling", () => {
+  describe("when navmapThumbnail is a verbatim https url with breakout characters", () => {
+    let deployment: typeof contentEntitySceneGenesisPlaza
+
+    beforeEach(() => {
+      deployment = {
+        ...contentEntitySceneGenesisPlaza,
+        metadata: {
+          ...contentEntitySceneGenesisPlaza.metadata,
+          display: {
+            navmapThumbnail: `https://a"><script>alert(1)</script><meta name="x`,
+          },
+        },
+      }
+    })
+
+    it("should drop the payload and fall back to the map thumbnail", () => {
+      expect(getThumbnailFromContentDeployment(deployment)).toBe(
+        genesisPlazaThumbnailMap
+      )
+    })
+  })
+
+  describe("when navmapThumbnail is a valid external https url", () => {
+    let deployment: typeof contentEntitySceneGenesisPlaza
+
+    beforeEach(() => {
+      deployment = {
+        ...contentEntitySceneGenesisPlaza,
+        metadata: {
+          ...contentEntitySceneGenesisPlaza.metadata,
+          display: {
+            navmapThumbnail: "https://cdn.decentraland.org/thumb.png",
+          },
+        },
+      }
+    })
+
+    it("should preserve the external thumbnail url", () => {
+      expect(getThumbnailFromContentDeployment(deployment)).toBe(
+        "https://cdn.decentraland.org/thumb.png"
+      )
+    })
   })
 })
 

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -99,6 +99,35 @@ function explorerWorldUrl(place: Pick<PlaceAttributes, "world_name">): string {
   return target.toString()
 }
 
+/**
+ * Validates that a user-supplied image/thumbnail value is a safe absolute http(s)
+ * URL and returns it normalized, or `null` when it is not parseable as such.
+ *
+ * Scene `navmapThumbnail` and world `thumbnailUrl` values are attacker-controlled and
+ * were previously stored verbatim into `Place.image` / `World.image`. A value such as
+ * `https://a"><meta http-equiv="refresh" ...>` would then be injected unescaped into
+ * the social/OpenGraph HTML (and returned raw in API responses), enabling stored XSS /
+ * open redirect. Parsing through `URL` rejects non-URL payloads and percent-encodes any
+ * HTML-breakout characters, so the stored value can never carry a raw `"`, `<` or `>`.
+ */
+export function sanitizeImageUrl(
+  value: string | null | undefined
+): string | null {
+  if (!value) {
+    return null
+  }
+
+  try {
+    const url = new URL(value)
+    if (url.protocol !== "https:" && url.protocol !== "http:") {
+      return null
+    }
+    return url.toString()
+  } catch {
+    return null
+  }
+}
+
 /** @deprecated */
 export function getThumbnailFromDeployment(deployment: ContentEntityScene) {
   const positions = (deployment?.pointers || []).sort()
@@ -112,6 +141,10 @@ export function getThumbnailFromDeployment(deployment: ContentEntityScene) {
     } else {
       thumbnail = `${CONTENT_SERVER_URL}/content/contents/${content.hash}`
     }
+  } else if (thumbnail) {
+    // A verbatim `https://` navmapThumbnail is attacker-controlled and stored as-is.
+    // Keep it only if it is a safe http(s) URL so it cannot inject markup downstream.
+    thumbnail = sanitizeImageUrl(thumbnail)
   }
 
   if (!thumbnail) {
@@ -141,6 +174,10 @@ export function getThumbnailFromContentDeployment(
     } else {
       thumbnail = `${contentServerUrl}/contents/${content.hash}`
     }
+  } else if (thumbnail) {
+    // A verbatim `https://` navmapThumbnail is attacker-controlled and stored as-is.
+    // Keep it only if it is a safe http(s) URL so it cannot inject markup downstream.
+    thumbnail = sanitizeImageUrl(thumbnail)
   }
 
   if (!thumbnail && deployment?.metadata?.worldConfiguration) {

--- a/src/entities/Social/routes.test.ts
+++ b/src/entities/Social/routes.test.ts
@@ -1,0 +1,123 @@
+import { randomUUID } from "crypto"
+
+import { Request, Response } from "express"
+
+import { injectPlaceMetadata, injectWorldMetadata } from "./routes"
+import { placeGenesisPlazaWithAggregatedAttributes } from "../../__data__/placeGenesisPlazaWithAggregatedAttributes"
+import { worldPlaceParalax } from "../../__data__/world"
+import PlaceModel from "../Place/model"
+import { AggregatePlaceAttributes } from "../Place/types"
+import WorldModel from "../World/model"
+import { AggregateWorldAttributes } from "../World/types"
+
+const BREAKOUT = `https://a"><script>alert(1)</script><meta name="x`
+
+describe("injectPlaceMetadata", () => {
+  let res: Response
+  let findById: jest.SpyInstance
+
+  beforeEach(() => {
+    res = { set: jest.fn() } as unknown as Response
+    findById = jest.spyOn(PlaceModel, "findByIdWithAggregates")
+  })
+
+  afterEach(() => {
+    findById.mockReset()
+  })
+
+  describe("when the stored place image contains HTML-breakout characters", () => {
+    let html: string
+
+    beforeEach(async () => {
+      const id = randomUUID()
+      findById.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        image: BREAKOUT,
+      } as AggregatePlaceAttributes)
+      const req = { query: { id } } as unknown as Request
+      html = (await injectPlaceMetadata(req, res)) as unknown as string
+    })
+
+    it("should not render a live script element from the stored image", () => {
+      expect(html).not.toContain("<script>alert(1)</script>")
+    })
+
+    it("should not emit the crafted payload as the og:image content", () => {
+      expect(html).not.toContain(BREAKOUT)
+    })
+  })
+
+  describe("when the stored place image is a valid https url", () => {
+    let html: string
+
+    beforeEach(async () => {
+      const id = randomUUID()
+      findById.mockResolvedValueOnce({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        image: "https://cdn.decentraland.org/thumb.png",
+      } as AggregatePlaceAttributes)
+      const req = { query: { id } } as unknown as Request
+      html = (await injectPlaceMetadata(req, res)) as unknown as string
+    })
+
+    it("should render it as the og:image content", () => {
+      expect(html).toContain(`content="https://cdn.decentraland.org/thumb.png"`)
+    })
+  })
+})
+
+describe("injectWorldMetadata", () => {
+  let res: Response
+  let findById: jest.SpyInstance
+
+  beforeEach(() => {
+    res = { set: jest.fn() } as unknown as Response
+    findById = jest.spyOn(WorldModel, "findByIdWithAggregates")
+  })
+
+  afterEach(() => {
+    findById.mockReset()
+  })
+
+  describe("when the stored world image contains HTML-breakout characters", () => {
+    let html: string
+
+    beforeEach(async () => {
+      findById.mockResolvedValueOnce({
+        ...worldPlaceParalax,
+        image: BREAKOUT,
+      } as unknown as AggregateWorldAttributes)
+      const req = {
+        query: { name: worldPlaceParalax.world_name },
+      } as unknown as Request
+      html = (await injectWorldMetadata(req, res)) as unknown as string
+    })
+
+    it("should not render a live script element from the stored image", () => {
+      expect(html).not.toContain("<script>alert(1)</script>")
+    })
+
+    it("should not emit the crafted payload as the og:image content", () => {
+      expect(html).not.toContain(BREAKOUT)
+    })
+  })
+
+  describe("when the stored world image is a valid https url", () => {
+    let html: string
+
+    beforeEach(async () => {
+      findById.mockResolvedValueOnce({
+        ...worldPlaceParalax,
+        image: "https://cdn.decentraland.org/thumb.png",
+      } as unknown as AggregateWorldAttributes)
+      const req = {
+        query: { name: worldPlaceParalax.world_name },
+      } as unknown as Request
+      html = (await injectWorldMetadata(req, res)) as unknown as string
+    })
+
+    it("should render it as the og:image content", () => {
+      expect(html).toContain(`content="https://cdn.decentraland.org/thumb.png"`)
+    })
+  })
+})

--- a/src/entities/Social/routes.ts
+++ b/src/entities/Social/routes.ts
@@ -9,7 +9,7 @@ import copies from "../../intl/en.json"
 import toCanonicalPosition from "../../utils/position/toCanonicalPosition"
 import PlaceModel from "../Place/model"
 import { AggregatePlaceAttributes, PlaceListOrderBy } from "../Place/types"
-import { placeUrl, siteUrl, worldUrl } from "../Place/utils"
+import { placeUrl, sanitizeImageUrl, siteUrl, worldUrl } from "../Place/utils"
 import WorldModel from "../World/model"
 import { AggregateWorldAttributes } from "../World/types"
 
@@ -54,7 +54,10 @@ export async function injectPlaceMetadata(req: Request, res: Response) {
       ...(copies.social.place as any),
       title: escape(place.title || "") + " | Decentraland Place",
       description: escape((place.description || "").trim()),
-      image: place.image || "",
+      // Sanitize at the sink too: a malicious value persisted before ingestion
+      // sanitization existed (or written by any other path) would otherwise be
+      // rendered raw into the OG/social HTML by the locked decentraland-gatsby.
+      image: sanitizeImageUrl(place.image) || "",
       url: placeUrl(place),
       "twitter:card": "summary_large_image",
     })
@@ -85,7 +88,10 @@ export async function injectWorldMetadata(req: Request, res: Response) {
       ...(copies.social.place as any),
       title: escape(world.title || "") + " | Decentraland Place",
       description: escape((world.description || "").trim()),
-      image: world.image || "",
+      // Sanitize at the sink too: a malicious value persisted before ingestion
+      // sanitization existed (or written by any other path) would otherwise be
+      // rendered raw into the OG/social HTML by the locked decentraland-gatsby.
+      image: sanitizeImageUrl(world.image) || "",
       url: worldUrl(world),
       "twitter:card": "summary_large_image",
     })

--- a/test/integration/handleWorldSettingsChanged.test.ts
+++ b/test/integration/handleWorldSettingsChanged.test.ts
@@ -171,6 +171,59 @@ describe("handleWorldSettingsChanged integration", () => {
     })
   })
 
+  describe("when a settings event omits thumbnailUrl for an existing world that has an image", () => {
+    beforeEach(async () => {
+      const createEvent = createWorldSettingsChangedEvent({
+        key: "imageworld.dcl.eth",
+        metadata: {
+          worldName: "imageworld.dcl.eth",
+          title: "Image World",
+          thumbnailUrl: "https://example.com/thumb.png",
+        },
+      })
+      await handleWorldSettingsChanged(createEvent)
+
+      const updateEvent = createWorldSettingsChangedEvent({
+        key: "imageworld.dcl.eth",
+        metadata: {
+          worldName: "imageworld.dcl.eth",
+          title: "Image World Updated",
+        },
+      })
+      await handleWorldSettingsChanged(updateEvent)
+    })
+
+    it("should preserve the existing image instead of clearing it", async () => {
+      const response = await supertest(app)
+        .get("/api/worlds/imageworld.dcl.eth")
+        .expect(200)
+
+      expect(response.body.data.image).toBe("https://example.com/thumb.png")
+    })
+  })
+
+  describe("when a settings event provides a thumbnailUrl with HTML-breakout characters", () => {
+    beforeEach(async () => {
+      const event = createWorldSettingsChangedEvent({
+        key: "xssworld.dcl.eth",
+        metadata: {
+          worldName: "xssworld.dcl.eth",
+          title: "XSS World",
+          thumbnailUrl: `https://a"><script>alert(1)</script><meta name="x`,
+        },
+      })
+      await handleWorldSettingsChanged(event)
+    })
+
+    it("should not store the crafted value as the world image", async () => {
+      const response = await supertest(app)
+        .get("/api/worlds/xssworld.dcl.eth")
+        .expect(200)
+
+      expect(response.body.data.image).toBeNull()
+    })
+  })
+
   describe("when the event is missing the world name (key)", () => {
     beforeEach(async () => {
       const event = createWorldSettingsEventMissingKey()


### PR DESCRIPTION
## what

a scene's `display.navmapThumbnail` and a world's `thumbnailUrl` are attacker-controlled. `getThumbnailFromContentDeployment` / `getThumbnailFromDeployment` only resolve a thumbnail to a content hash when it does **not** start with `https://`; a `https://`-prefixed value is kept verbatim and stored into `Place.image`, and `handleWorldSettingsChanged` stored `thumbnailUrl` straight into `World.image`.

the social/opengraph endpoint (`/places/place/`, `/places/world/`) then interpolates `Place.image` into a `<meta content="...">` attribute. a filename such as:

```
https://x"><script>alert(1)</script><meta name="y
```

breaks out of the attribute and becomes live markup — stored xss / defacement served from the official places origin. the precondition is only normal authorization to publish one scene.

## change

add `sanitizeImageUrl(value)`:
- returns `null` for empty / unparseable values
- parses through `URL` and rejects any non-`http(s)` protocol (blocks `javascript:`, `data:`, …)
- returns the normalized url, so `"`, `<`, `>` are percent-encoded and can never be stored raw

apply it at every attacker-reachable ingestion sink:
- `getThumbnailFromContentDeployment` and `getThumbnailFromDeployment` — a rejected verbatim thumbnail falls back to the generated map thumbnail
- `handleWorldSettingsChanged` — a rejected `thumbnailUrl` is stored as `null`

## defense-in-depth context

this is the ingestion layer. the same payload is also blocked at:
- the deployment gate: [core-libs#55](https://github.com/decentraland/core-libs/pull/55) (catalyst scenes) and [worlds-content-server#514](https://github.com/decentraland/worlds-content-server/pull/514) (worlds)
- the html sink: [decentraland-gatsby#1327](https://github.com/decentraland/decentraland-gatsby/pull/1327) (escapes `image`/`url` in `replaceHelmetMetadata`)

this places-side fix is independent and self-contained — it closes the stored xss at ingestion regardless of the installed `decentraland-gatsby` version, and covers already-deployed scenes that the deployment-gate fixes won't retroactively reject.

## tests

added unit coverage for `sanitizeImageUrl` (valid https, breakout string, non-http protocol, undefined) and for `getThumbnailFromContentDeployment` (breakout `https://` value dropped → map fallback; valid external https preserved). full `Place/utils` suite green (`23/23`).