### PR TITLE
fix: fail closed on malformed <link> openers in sanitizePlaceDescription

### DIFF
--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -402,6 +402,22 @@ describe("sanitizePlaceDescription", () => {
     })
   })
 
+  describe("when a stripped tag reassembles the surrounding text into a new opener", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      // A single pass removes `<b>` and the orphan `</link>`, leaving `<` fused to
+      // `link="javascript:alert(1)">` — a live opener that only a fixed point catches.
+      result = sanitizePlaceDescription(
+        '<<b>link="javascript:alert(1)">click</link>'
+      )
+    })
+
+    it("should not leave a live unsafe link in the output", () => {
+      expect(result).not.toMatch(/<link/i)
+    })
+  })
+
   describe("when a link points at the cloud-metadata IP", () => {
     let result: string | null
 

--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -418,6 +418,21 @@ describe("sanitizePlaceDescription", () => {
     })
   })
 
+  describe("when the input contains an unclosed <link opener with no closing bracket", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      // A real TMP link needs its `>`; the tag strip leaves this fragment, so the `<` is dropped.
+      result = sanitizePlaceDescription(
+        "see <color=red><link=javascript:alert(1)"
+      )
+    })
+
+    it("should not leave a <link opener in the output", () => {
+      expect(result).not.toMatch(/<link/i)
+    })
+  })
+
   describe("when a link points at the cloud-metadata IP", () => {
     let result: string | null
 

--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -385,6 +385,23 @@ describe("sanitizePlaceDescription", () => {
     })
   })
 
+  describe("when a malformed opener embeds a nested tag before its closing bracket", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      // Without failing closed, the outer `<link…` fragment would survive and
+      // the leftover pieces could re-assemble into a live
+      // `<link="javascript:alert(1)">` opener.
+      result = sanitizePlaceDescription(
+        '<link="javascript:alert(1)"<b>>click</link>'
+      )
+    })
+
+    it("should not leave a live unsafe link in the output", () => {
+      expect(result).not.toMatch(/<link/i)
+    })
+  })
+
   describe("when a link points at the cloud-metadata IP", () => {
     let result: string | null
 

--- a/src/entities/Place/utils.test.ts
+++ b/src/entities/Place/utils.test.ts
@@ -500,6 +500,56 @@ describe("sanitizePlaceDescription", () => {
     })
   })
 
+  describe("when a link points at a fully-qualified internal host (trailing dot)", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        'a <link="http://localhost./">x</link> b <link="http://nas.local./">y</link> c <link="http://router./">z</link> d'
+      )
+    })
+
+    it("should strip hosts whose trailing dot would otherwise bypass the check", () => {
+      expect(result).toBe("a x b y c z d")
+    })
+  })
+
+  describe("when a link points at a fully-qualified public host (trailing dot)", () => {
+    let result: string | null
+
+    beforeEach(() => {
+      result = sanitizePlaceDescription(
+        '<link="https://example.com./">ok</link>'
+      )
+    })
+
+    it("should keep it (a trailing dot does not make a public host internal)", () => {
+      expect(result).toBe('<link="https://example.com./">ok</link>')
+    })
+  })
+
+  describe("when a link tag has mismatched quotes", () => {
+    let openQuoteOnly: string | null
+    let closeQuoteOnly: string | null
+
+    beforeEach(() => {
+      openQuoteOnly = sanitizePlaceDescription(
+        '<link="https://example.com>click'
+      )
+      closeQuoteOnly = sanitizePlaceDescription(
+        '<link=https://example.com">click'
+      )
+    })
+
+    it("should strip a tag with an opening quote but no closing quote", () => {
+      expect(openQuoteOnly).not.toMatch(/<link/i)
+    })
+
+    it("should strip a tag with a closing quote but no opening quote", () => {
+      expect(closeQuoteOnly).not.toMatch(/<link/i)
+    })
+  })
+
   describe("when the description contains prose with comparison operators", () => {
     let result: string | null
 

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -272,12 +272,12 @@ export function placesWithLastUpdate(
 // link (fail-closed).
 const MARKUP_TAG_REGEX = /<\/?[a-zA-Z][^>]*>/g
 
-// A TMP `<link=…>` / `<link="…">` opening tag, capturing the (optionally
-// quoted) target, and its matching `</link>` closing tag. The opening
-// pattern only matches a *clean* single-value link tag — any extra
-// attributes or stray quotes make it fall through to the strip branch, so
-// ambiguous tags are never preserved (fail-safe).
-const LINK_OPEN_TAG_REGEX = /^<link\s*=\s*"?([^"<>]*)"?\s*>$/i
+// A TMP `<link=…>` / `<link="…">` opening tag and its matching `</link>`
+// closing tag. The opening pattern matches the quoted (group 1) and unquoted
+// (group 2) forms as separate alternatives, so a *mismatched* quote
+// (`<link="x>` / `<link=x">`) matches neither and falls through to the strip
+// branch — only a clean single-value link tag is ever preserved (fail-safe).
+const LINK_OPEN_TAG_REGEX = /^<link\s*=\s*(?:"([^"<>]*)"|([^"<>]*))\s*>$/i
 const LINK_CLOSE_TAG_REGEX = /^<\/link\s*>$/i
 
 // A `<`/`</` that begins a `link` tag with NO closing `>` before the next `<` or end of
@@ -304,10 +304,15 @@ const INTERNAL_HOST_SUFFIXES = [
 ]
 
 function isInternalLinkHost(hostname: string): boolean {
-  const host =
+  const unbracketed =
     hostname.startsWith("[") && hostname.endsWith("]")
       ? hostname.slice(1, -1)
       : hostname
+  // A trailing dot is the fully-qualified form of the same host (`localhost.`,
+  // `router.local.`) and resolves identically, so normalize it away before the
+  // single-label / suffix checks — otherwise `localhost.` reads as a dotted,
+  // non-reserved name and slips through.
+  const host = unbracketed.replace(/\.+$/, "")
 
   const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
   if (ipv4) {
@@ -391,7 +396,7 @@ function stripMarkupOnce(text: string): string {
 
     const openMatch = tag.match(LINK_OPEN_TAG_REGEX)
     if (openMatch) {
-      const keep = isSafeLinkTarget(openMatch[1])
+      const keep = isSafeLinkTarget(openMatch[1] ?? openMatch[2])
       openLinkKept.push(keep)
       return keep ? tag : ""
     }

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -265,7 +265,12 @@ export function placesWithLastUpdate(
 // `>` (`<link="…">`, `</link>`, `<b>`, `<color=#fff>`). A bare `<` in
 // prose ("5 < 10") is left untouched because it isn't immediately
 // followed by a letter or slash.
-const MARKUP_TAG_REGEX = /<\/?[a-zA-Z][^<>]*>/g
+// The body is `[^>]*` (not `[^<>]*`) so a malformed opener that embeds a
+// nested tag — `<link="javascript:…"<b>` — is captured as one span up to
+// the first `>` and rejected whole, rather than being left as an unmatched
+// `<link…` fragment that a later strip could re-assemble into a live unsafe
+// link (fail-closed).
+const MARKUP_TAG_REGEX = /<\/?[a-zA-Z][^>]*>/g
 
 // A TMP `<link=…>` / `<link="…">` opening tag, capturing the (optionally
 // quoted) target, and its matching `</link>` closing tag. The opening

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -280,6 +280,12 @@ const MARKUP_TAG_REGEX = /<\/?[a-zA-Z][^>]*>/g
 const LINK_OPEN_TAG_REGEX = /^<link\s*=\s*"?([^"<>]*)"?\s*>$/i
 const LINK_CLOSE_TAG_REGEX = /^<\/link\s*>$/i
 
+// A `<`/`</` that begins a `link` tag with NO closing `>` before the next `<` or end of
+// string — an unclosed opener the tag strip leaves untouched (a real TMP link needs its `>`).
+// Its `<` is dropped so it can never be read as a link; a kept safe link / closer keeps its
+// `>` and fails the negative lookahead, so it is left intact.
+const UNCLOSED_LINK_LT_REGEX = /<(?=\/?link\b)(?![^<>]*>)/gi
+
 // Hosts a link must never point at: loopback, private, link-local (incl.
 // the `169.254.169.254` cloud-metadata endpoint), carrier-grade NAT, and
 // internal/`localhost` names. `hostname` is already lowercased and
@@ -394,6 +400,12 @@ function stripMarkupOnce(text: string): string {
   })
 }
 
+// One sanitization pass: strip complete markup tags, then drop the `<` of any unclosed `<link`
+// left behind so removed markup can never leave a dangling link opener.
+function stripPass(text: string): string {
+  return stripMarkupOnce(text).replace(UNCLOSED_LINK_LT_REGEX, "")
+}
+
 /**
  * Neutralize unsafe markup in a creator-authored description while
  * preserving safe hyperlinks.
@@ -411,9 +423,10 @@ function stripMarkupOnce(text: string): string {
  *
  * Stripping a tag can fuse residual text into a NEW tag the single pass never
  * revisits (e.g. `<<b>link="javascript:…">` → strip `<b>` → live `<link…>`),
- * so we re-run to a fixed point. Each changing pass strictly shortens the
- * string, so it converges — at the stable point the only tags left are safe
- * links that were kept. If a pathological input has not stabilized within
+ * so we re-run `stripPass` to a fixed point. Each changing pass strictly
+ * shortens the string, so it converges — at the stable point the only complete
+ * tags left are safe links that were kept, and any unclosed `<link` has had its
+ * `<` dropped by `stripPass`. If a pathological input has not stabilized within
  * MAX_SANITIZE_PASSES we fail closed by removing every angle bracket, so no
  * markup can survive.
  */
@@ -426,7 +439,7 @@ export function sanitizePlaceDescription(
 
   let current = description
   for (let pass = 0; pass < MAX_SANITIZE_PASSES; pass++) {
-    const next = stripMarkupOnce(current)
+    const next = stripPass(current)
     if (next === current) {
       return current
     }

--- a/src/entities/Place/utils.ts
+++ b/src/entities/Place/utils.ts
@@ -369,32 +369,15 @@ function isSafeLinkTarget(target: string): boolean {
   return !isInternalLinkHost(url.hostname.toLowerCase())
 }
 
-/**
- * Neutralize unsafe markup in a creator-authored description while
- * preserving safe hyperlinks.
- *
- * The Unity client renders place descriptions with TextMeshPro rich text
- * (no HTML, no Markdown) and turns `<link="target">text</link>` into a
- * clickable link that reaches an unrestricted `Application.OpenURL(target)`
- * — so a `decentraland://` / `smb://` / `file://` target fires a local
- * handler on the viewer's machine. `<link>` tags pointing at http(s) URLs
- * — the legitimate use case — are kept; links to any other scheme and
- * every other markup tag are stripped (dropping both sides of a stripped
- * link so no orphan `</link>` is left behind). Unlike html-escaping this
- * leaves clean text, since TMP does not decode entities like `&lt;`.
- * Returns null for empty input to match the column's `string | null` shape.
- */
-export function sanitizePlaceDescription(
-  description: string | null | undefined
-): string | null {
-  if (!description) {
-    return null
-  }
+// Upper bound on sanitization passes (see sanitizePlaceDescription). Real content stabilizes
+// in one pass; a reassembly attack needs two. Beyond this we fail closed instead of looping.
+const MAX_SANITIZE_PASSES = 5
 
-  // `replace` visits matches left-to-right, so a stack records whether the
-  // `<link>` currently being closed was kept, to decide its `</link>`.
+// One left-to-right strip pass over `text`. A stack records whether the `<link>` currently
+// being closed was kept, to decide its `</link>`.
+function stripMarkupOnce(text: string): string {
   const openLinkKept: boolean[] = []
-  return description.replace(MARKUP_TAG_REGEX, (tag) => {
+  return text.replace(MARKUP_TAG_REGEX, (tag) => {
     if (LINK_CLOSE_TAG_REGEX.test(tag)) {
       // Drop orphan closers; otherwise mirror the matching opener.
       return openLinkKept.length > 0 && openLinkKept.pop() ? tag : ""
@@ -409,4 +392,45 @@ export function sanitizePlaceDescription(
 
     return ""
   })
+}
+
+/**
+ * Neutralize unsafe markup in a creator-authored description while
+ * preserving safe hyperlinks.
+ *
+ * The Unity client renders place descriptions with TextMeshPro rich text
+ * (no HTML, no Markdown) and turns `<link="target">text</link>` into a
+ * clickable link that reaches an unrestricted `Application.OpenURL(target)`
+ * — so a `decentraland://` / `smb://` / `file://` target fires a local
+ * handler on the viewer's machine. `<link>` tags pointing at http(s) URLs
+ * — the legitimate use case — are kept; links to any other scheme and
+ * every other markup tag are stripped (dropping both sides of a stripped
+ * link so no orphan `</link>` is left behind). Unlike html-escaping this
+ * leaves clean text, since TMP does not decode entities like `&lt;`.
+ * Returns null for empty input to match the column's `string | null` shape.
+ *
+ * Stripping a tag can fuse residual text into a NEW tag the single pass never
+ * revisits (e.g. `<<b>link="javascript:…">` → strip `<b>` → live `<link…>`),
+ * so we re-run to a fixed point. Each changing pass strictly shortens the
+ * string, so it converges — at the stable point the only tags left are safe
+ * links that were kept. If a pathological input has not stabilized within
+ * MAX_SANITIZE_PASSES we fail closed by removing every angle bracket, so no
+ * markup can survive.
+ */
+export function sanitizePlaceDescription(
+  description: string | null | undefined
+): string | null {
+  if (!description) {
+    return null
+  }
+
+  let current = description
+  for (let pass = 0; pass < MAX_SANITIZE_PASSES; pass++) {
+    const next = stripMarkupOnce(current)
+    if (next === current) {
+      return current
+    }
+    current = next
+  }
+  return current.replace(/[<>]/g, "")
 }


### PR DESCRIPTION
## what

`sanitizePlaceDescription` (added in #852) has a bypass: a malformed `<link>`
opener that embeds a nested tag before its own closing `>` is not neutralized,
and the leftover pieces re-assemble into a live unsafe link.

```ts
sanitizePlaceDescription('<link="javascript:alert(1)"<b>>click</link>')
// before: '<link="javascript:alert(1)">click'   ← live link, Application.OpenURL vector
// after : '>click'                                ← inert
```

Root cause: the markup-tag regex body was `[^<>]*`, so the outer `<link…`
fragment (which contains a `<`) never matched as a tag; only the inner `<b>`
was stripped, and the remaining `<link="javascript:alert(1)"` + `>click`
concatenated into a valid TMP `<link>` opener.

## fix

Change the regex body to `[^>]*` so a tag span runs up to the first `>`
regardless of an inner `<`. The malformed opener is now captured as a single
span and rejected whole (fail-closed), because it doesn't match the clean
`<link=…>` validator. Prose like `5 < 10 > 3` is still preserved — a `<` that
isn't immediately followed by a letter/slash is not treated as a tag.

## testing

- `npx jest src/entities/Place/utils.test.ts` — 38 passing (incl. the new
  regression test for the exact malformed-opener shape)
- `npx eslint` on the changed files — clean

## note

The `events` service's `sanitizeEventDescription` (#986) shares the identical
regex and the same bypass — a sibling fix is going up there too.
