### PR TITLE
fix: harden report uploads and moderation updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+lib
+.cache
+.git
+.env*
+coverage
+tmp

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,7 +22,6 @@ COPY ./package.json         /app/package.json
 RUN npm install
 
 COPY ./src                  /app/src
-COPY ./.env                 /app/.env.production
 COPY ./entrypoint.sh        /app/entrypoint.sh
 COPY ./tsconfig.json        /app/tsconfig.json
 

--- a/docs/ai-agent-context.md
+++ b/docs/ai-agent-context.md
@@ -12,7 +12,7 @@ The Decentraland Places service is a comprehensive API solution for discovering,
 - **Category Management**: Dynamic categorization with automatic POI (Point of Interest) categorization
 - **Hot Scenes Tracking**: Real-time monitoring of active scenes with user counts from Catalyst realms
 - **Map Integration**: Specialized endpoints for coordinate-based queries optimized for map visualization
-- **Content Moderation**: Content rating system (PR/E/T/A/R) and report generation with S3 signed URLs
+- **Content Moderation**: Content rating system (PR/E/T/A/R) and report generation with constrained S3 signed POST policies
 - **Gatsby Frontend**: Static site generation for place exploration interface with HTTPS support
 
 ## Communication Pattern
@@ -43,7 +43,7 @@ The Decentraland Places service is a comprehensive API solution for discovering,
 - **Decentraland Catalyst**: Source of scene metadata and deployment information (`https://peer.decentraland.org` by default)
 - **World Content Server**: Source of world metadata and deployment information for Decentraland Worlds
 - **Decentraland Realm Provider**: Real-time hot scenes data and user count information from active realms
-- **AWS S3**: Content moderation report storage with pre-signed upload URLs (60s expiry)
+- **AWS S3**: Private content moderation report storage with pre-signed POST policies (60s expiry, JSON-only, 1 MiB maximum)
 - **Decentraland Data Team CDN**: Scene statistics and visit data (`https://cdn-data.decentraland.org/`)
 
 ## Key Concepts
@@ -74,7 +74,7 @@ The service exposes a REST API under `/api` with comprehensive documentation in 
 - **Map**: `/api/map`, `/api/map/places` (coordinate-based queries with higher limits)
 - **Categories**: `/api/categories` (with optional `target` filter for places/worlds/all)
 - **Interactions**: `/api/places/:id/likes`, `/api/places/:id/favorites` (authentication required)
-- **Reports**: `/api/report` (authentication required, returns S3 signed URL)
+- **Reports**: `/api/report` (authentication required, returns a constrained S3 signed POST policy)
 - **Social**: `/places/place/`, `/places/world/` (metadata injection for social sharing)
 - **Creator Queries**: `/api/places?creator_address=0x...` (lookup places by scene creator for tipping integration)
 - **SDK Filtering**: `/api/places?sdk=7` (filter by SDK version, major version prefix match - sdk=7 matches 7, 7.0.0, 7.3.27, etc.)

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -530,6 +530,12 @@ paths:
                 $ref: '#/components/schemas/Error'
         '404':
           $ref: '#/components/responses/NotFound'
+        '409':
+          description: Conflict - the place became ineligible before the rating update completed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
 
   /places/{place_id}/ranking:
     put:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -108,7 +108,7 @@ tags:
       Users can like or dislike places to help others discover quality content.
   - name: Report
     description: |
-      Generate signed URLs for uploading content reports (requires authentication).
+      Generate constrained signed POST policies for uploading content reports (requires authentication).
 
 paths:
   /places:
@@ -1685,25 +1685,27 @@ paths:
     post:
       tags:
         - Report
-      summary: Get signed S3 upload URL 🔒
+      summary: Get signed S3 upload policy 🔒
       security:
         - BearerAuth: []
       description: |
-        Generate a pre-signed S3 URL for uploading content reports. **Requires authentication.**
+        Generate a pre-signed S3 POST policy for uploading JSON content reports. **Requires authentication.**
 
         **Use Case:** Users can report inappropriate content or issues. This endpoint provides a secure
-        upload URL that expires after 60 seconds.
+        upload policy that expires after 60 seconds and accepts at most 1 MiB.
 
         **Process:**
-        1. Call this endpoint to get a signed URL
-        2. PUT your report JSON directly to the signed URL
+        1. Call this endpoint to get a signed URL and form fields
+        2. POST the report to `signed_url` as `multipart/form-data`, including every returned field
+           and a `file` part containing JSON
         3. Report is stored privately for moderation review
 
-        **Security:** The signed URL is temporary and scoped to the authenticated user.
+        **Security:** The policy is temporary, content-type and size constrained, uses an unpredictable
+        object key, and records the authenticated wallet in S3 metadata.
       operationId: getReportSignedUrl
       responses:
         '200':
-          description: Signed URL generated successfully
+          description: Signed POST policy generated successfully
           content:
             application/json:
               schema:
@@ -1717,11 +1719,33 @@ paths:
                       signed_url:
                         type: string
                         format: uri
-                        description: Pre-signed S3 URL for PUT upload (expires in 60s)
+                        description: S3 endpoint for a multipart POST upload (expires in 60s)
+                      fields:
+                        type: object
+                        additionalProperties:
+                          type: string
+                        description: Fields that must be included unchanged in the multipart form
+                      max_file_size:
+                        type: integer
+                        format: int32
+                        description: Maximum accepted file size in bytes
+                        minimum: 1
+                        maximum: 1048576
+                    required:
+                      - signed_url
+                      - fields
+                      - max_file_size
               example:
                 ok: true
                 data:
-                  signed_url: "https://s3.amazonaws.com/bucket/path?signature=..."
+                  signed_url: "https://s3.amazonaws.com/content-moderation-bucket"
+                  fields:
+                    key: "8a51d63d-0634-4c3c-a809-89f7499bbfc5.json"
+                    Content-Type: "application/json"
+                    acl: "private"
+                    Policy: "eyJleHBpcmF0aW9uIjoi..."
+                    X-Amz-Signature: "..."
+                  max_file_size: 1048576
         '401':
           $ref: '#/components/responses/Unauthorized'
 

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -108,7 +108,7 @@ tags:
       Users can like or dislike places to help others discover quality content.
   - name: Report
     description: |
-      Generate constrained signed POST policies for uploading content reports (requires authentication).
+      Generate signed upload credentials for content reports (requires authentication).
 
 paths:
   /places:
@@ -1691,27 +1691,30 @@ paths:
     post:
       tags:
         - Report
-      summary: Get signed S3 upload policy 🔒
+      summary: Get signed S3 upload credentials 🔒
       security:
         - BearerAuth: []
       description: |
-        Generate a pre-signed S3 POST policy for uploading JSON content reports. **Requires authentication.**
+        Generate signed S3 credentials for uploading JSON content reports. **Requires authentication.**
 
         **Use Case:** Users can report inappropriate content or issues. This endpoint provides a secure
-        upload policy that expires after 60 seconds and accepts at most 1 MiB.
+        multipart POST policy that expires after 60 seconds and accepts at most 1 MiB.
 
         **Process:**
-        1. Call this endpoint to get a signed URL and form fields
-        2. POST the report to `signed_url` as `multipart/form-data`, including every returned field
+        1. Call this endpoint to get the `upload` object
+        2. POST the report to `upload.url` as `multipart/form-data`, including every returned field
            and a `file` part containing JSON
         3. Report is stored privately for moderation review
 
         **Security:** The policy is temporary, content-type and size constrained, uses an unpredictable
         object key, and records the authenticated wallet in S3 metadata.
+
+        **Compatibility:** `signed_url` remains temporarily available for legacy clients that upload
+        with PUT. New clients must use the constrained `upload` object.
       operationId: getReportSignedUrl
       responses:
         '200':
-          description: Signed POST policy generated successfully
+          description: Signed upload credentials generated successfully
           content:
             application/json:
               schema:
@@ -1725,33 +1728,52 @@ paths:
                       signed_url:
                         type: string
                         format: uri
-                        description: S3 endpoint for a multipart POST upload (expires in 60s)
-                      fields:
+                        deprecated: true
+                        description: Temporary pre-signed S3 URL for legacy PUT clients (expires in 60s)
+                      upload:
                         type: object
-                        additionalProperties:
-                          type: string
-                        description: Fields that must be included unchanged in the multipart form
-                      max_file_size:
-                        type: integer
-                        format: int32
-                        description: Maximum accepted file size in bytes
-                        minimum: 1
-                        maximum: 1048576
+                        properties:
+                          method:
+                            type: string
+                            enum:
+                              - POST
+                          url:
+                            type: string
+                            format: uri
+                            description: S3 endpoint for the multipart POST upload
+                          fields:
+                            type: object
+                            additionalProperties:
+                              type: string
+                            description: Fields that must be included unchanged in the multipart form
+                          max_file_size:
+                            type: integer
+                            format: int32
+                            description: Maximum accepted file size in bytes
+                            minimum: 1
+                            maximum: 1048576
+                        required:
+                          - method
+                          - url
+                          - fields
+                          - max_file_size
                     required:
                       - signed_url
-                      - fields
-                      - max_file_size
+                      - upload
               example:
                 ok: true
                 data:
-                  signed_url: "https://s3.amazonaws.com/content-moderation-bucket"
-                  fields:
-                    key: "8a51d63d-0634-4c3c-a809-89f7499bbfc5.json"
-                    Content-Type: "application/json"
-                    acl: "private"
-                    Policy: "eyJleHBpcmF0aW9uIjoi..."
-                    X-Amz-Signature: "..."
-                  max_file_size: 1048576
+                  signed_url: "https://s3.amazonaws.com/content-moderation-bucket/report.json?X-Amz-Signature=..."
+                  upload:
+                    method: "POST"
+                    url: "https://s3.amazonaws.com/content-moderation-bucket"
+                    fields:
+                      key: "8a51d63d-0634-4c3c-a809-89f7499bbfc5.json"
+                      Content-Type: "application/json"
+                      acl: "private"
+                      Policy: "eyJleHBpcmF0aW9uIjoi..."
+                      X-Amz-Signature: "..."
+                    max_file_size: 1048576
         '401':
           $ref: '#/components/responses/Unauthorized'
 

--- a/docs/postman-collection.json
+++ b/docs/postman-collection.json
@@ -807,10 +807,10 @@
     },
     {
       "name": "Reports",
-      "description": "User-generated content reports stored on S3 via signed urls.",
+      "description": "User-generated JSON content reports stored privately on S3 via constrained signed POST policies.",
       "item": [
         {
-          "name": "Request report signed URL",
+          "name": "Request report signed POST policy",
           "request": {
             "method": "POST",
             "header": [],
@@ -819,7 +819,7 @@
               "host": ["{{base_url}}"],
               "path": ["api", "report"]
             },
-            "description": "Returns a `{ signed_url: string }` that the client uses to PUT a JSON report payload directly to S3. The URL is bound to the caller's wallet address (recorded in S3 object metadata) and expires in ~60s. Requires auth-chain."
+            "description": "Returns `{ signed_url, fields, max_file_size }`. POST a multipart form to `signed_url`, copy every entry in `fields` unchanged, and include the JSON report as the `file` part. The policy expires in 60 seconds, permits at most 1 MiB, stores the object privately, and records the authenticated wallet in S3 metadata. Requires auth-chain."
           }
         }
       ]

--- a/docs/postman-collection.json
+++ b/docs/postman-collection.json
@@ -807,10 +807,10 @@
     },
     {
       "name": "Reports",
-      "description": "User-generated JSON content reports stored privately on S3 via constrained signed POST policies.",
+      "description": "User-generated JSON content reports stored privately on S3. New clients use constrained signed POST policies; signed PUT URLs remain temporarily available for legacy clients.",
       "item": [
         {
-          "name": "Request report signed POST policy",
+          "name": "Request report upload credentials",
           "request": {
             "method": "POST",
             "header": [],
@@ -819,7 +819,7 @@
               "host": ["{{base_url}}"],
               "path": ["api", "report"]
             },
-            "description": "Returns `{ signed_url, fields, max_file_size }`. POST a multipart form to `signed_url`, copy every entry in `fields` unchanged, and include the JSON report as the `file` part. The policy expires in 60 seconds, permits at most 1 MiB, stores the object privately, and records the authenticated wallet in S3 metadata. Requires auth-chain."
+            "description": "Returns a temporary legacy `signed_url` for existing PUT clients and a self-describing `{ upload: { method, url, fields, max_file_size } }` for new clients. New clients POST a multipart form to `upload.url`, copy every entry in `upload.fields` unchanged, and include the JSON report as the `file` part. The POST policy expires in 60 seconds, permits at most 1 MiB, stores the object privately, and records the authenticated wallet in S3 metadata. Requires auth-chain."
           }
         }
       ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,8 @@
         "typescript": "^5.9.3"
       },
       "engines": {
-        "node": "18.*",
-        "npm": "8.* || 9.*"
+        "node": "24.*",
+        "npm": "10.* || 11.*"
       }
     },
     "node_modules/@0xsequence/abi": {
@@ -889,12 +889,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -903,29 +903,29 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -960,13 +960,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -988,13 +988,13 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -1058,9 +1058,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1080,27 +1080,27 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1122,9 +1122,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1178,27 +1178,27 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1219,13 +1219,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1318,12 +1318,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2230,15 +2230,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helper-plugin-utils": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.29.0"
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helper-plugin-utils": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2903,31 +2903,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -2935,13 +2935,13 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2982,33 +2982,54 @@
       }
     },
     "node_modules/@coinbase/cdp-sdk": {
-      "version": "1.48.2",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.48.2.tgz",
-      "integrity": "sha512-phsHxF9q4CvF8H1b//aepxy8J/pdORT+btdqv7wbQ1YOi44QYfenima15N8Ok9lZE/XqY81BebsaBkyjqBJgig==",
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.54.0.tgz",
+      "integrity": "sha512-FfIJVEKAXgmr+dkXn/NBQO04/pps+oIgqEIdcmG67WZh+m07OsVnvSBEqEvbFO+VjSdaQAKu69EpO3NdHJd2Iw==",
       "license": "MIT",
       "dependencies": {
         "@solana-program/system": "^0.10.0",
         "@solana-program/token": "^0.9.0",
         "@solana/kit": "^5.5.1",
         "abitype": "1.0.6",
-        "axios": "1.13.6",
+        "axios": "1.16.0",
         "axios-retry": "^4.5.0",
+        "bs58": "^6.0.0",
         "jose": "^6.2.0",
         "md5": "^2.3.0",
         "uncrypto": "^0.1.3",
         "viem": "^2.47.0",
         "zod": "^3.25.76"
+      },
+      "peerDependencies": {
+        "@x402/core": "^2.19.0",
+        "@x402/evm": "^2.19.0",
+        "@x402/extensions": "^2.19.0",
+        "@x402/svm": "^2.19.0"
+      },
+      "peerDependenciesMeta": {
+        "@x402/core": {
+          "optional": true
+        },
+        "@x402/evm": {
+          "optional": true
+        },
+        "@x402/extensions": {
+          "optional": true
+        },
+        "@x402/svm": {
+          "optional": true
+        }
       }
     },
     "node_modules/@coinbase/cdp-sdk/node_modules/axios": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
-      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/@coinbase/cdp-sdk/node_modules/axios-retry": {
@@ -3640,10 +3661,20 @@
       }
     },
     "node_modules/@dcl/eslint-config/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3804,10 +3835,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5752,37 +5782,37 @@
       }
     },
     "node_modules/@hey-api/codegen-core": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.7.4.tgz",
-      "integrity": "sha512-DGd9yeSQzflOWO3Y5mt1GRXkXH9O/yIMgbxPjwLI3jwu/3nAjoXXD26lEeFb6tclYlg0JAqTIs5d930G/qxHeA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@hey-api/codegen-core/-/codegen-core-0.9.1.tgz",
+      "integrity": "sha512-s97jL1dgTMuiMHv2BZ1X4Tgd99Mf9GOvGdNqNcGwIMmnR+PgYNoraj4Zvp134MKsNCap/m7k0r0vKKnl56pj4w==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
-        "c12": "3.3.3",
+        "c12": "3.3.4",
         "color-support": "1.1.3"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
       }
     },
     "node_modules/@hey-api/json-schema-ref-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.3.1.tgz",
-      "integrity": "sha512-7atnpUkT8TyUPHYPLk91j/GyaqMuwTEHanLOe50Dlx0EEvNuQqFD52Yjg8x4KU0UFL1mWlyhE+sUE/wAtQ1N2A==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@hey-api/json-schema-ref-parser/-/json-schema-ref-parser-1.4.4.tgz",
+      "integrity": "sha512-otmd+zCxbYVBIp/mlMTnGkvlNYLkVKgs3VOIq0kSnenhB1+fRwLPQIeSwyWM6E51oXhUedkYjVsVpkVexeuJOA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@jsdevtools/ono": "7.1.3",
         "@types/json-schema": "7.0.15",
-        "js-yaml": "4.1.1"
+        "js-yaml": "4.2.0"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -5796,9 +5826,19 @@
       "peer": true
     },
     "node_modules/@hey-api/json-schema-ref-parser/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5809,27 +5849,28 @@
       }
     },
     "node_modules/@hey-api/openapi-ts": {
-      "version": "0.95.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.95.0.tgz",
-      "integrity": "sha512-lk5C+WKl5yqEmliQihEyhX/jNcWlAykTSEqkDeKa9xSq5YDAzOFvx7oos8YTqiIzdc4TemtlEaB8Rns7+8A0qg==",
+      "version": "0.99.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/openapi-ts/-/openapi-ts-0.99.0.tgz",
+      "integrity": "sha512-SePU/5oEWWkvUBYmvzdYRctseoLuskyhs4ET0RvLIcmzc8yLQoA2R+KtBIQ8bPsoSUB0m4E5SmBnl6aGSA0szQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.7.4",
-        "@hey-api/json-schema-ref-parser": "1.3.1",
-        "@hey-api/shared": "0.3.0",
-        "@hey-api/spec-types": "0.1.0",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/shared": "0.5.0",
+        "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
+        "@lukeed/ms": "2.0.2",
         "ansi-colors": "4.1.3",
         "color-support": "1.1.3",
-        "commander": "14.0.3",
-        "get-tsconfig": "4.13.6"
+        "commander": "15.0.0",
+        "get-tsconfig": "4.14.0"
       },
       "bin": {
         "openapi-ts": "bin/run.js"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -5839,46 +5880,33 @@
       }
     },
     "node_modules/@hey-api/openapi-ts/node_modules/commander": {
-      "version": "14.0.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
-      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-15.0.0.tgz",
+      "integrity": "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg==",
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=20"
-      }
-    },
-    "node_modules/@hey-api/openapi-ts/node_modules/get-tsconfig": {
-      "version": "4.13.6",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.6.tgz",
-      "integrity": "sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "resolve-pkg-maps": "^1.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@hey-api/shared": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.3.0.tgz",
-      "integrity": "sha512-G+4GPojdLEh9bUwRG88teMPM1HdqMm/IsJ38cbnNxhyDu1FkFGwilkA1EqnULCzfTam/ZoZkaLdmAd8xEh4Xsw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/shared/-/shared-0.5.0.tgz",
+      "integrity": "sha512-JN/j4Ebh4cJGYIQ5cwWuqe7GeSUyQoz7oC51WqyhKOcrejK6DKZMDkshc5d1eKTRuRL+rjozuRcoUaZZn2DGPw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@hey-api/codegen-core": "0.7.4",
-        "@hey-api/json-schema-ref-parser": "1.3.1",
-        "@hey-api/spec-types": "0.1.0",
+        "@hey-api/codegen-core": "0.9.1",
+        "@hey-api/json-schema-ref-parser": "1.4.4",
+        "@hey-api/spec-types": "0.2.0",
         "@hey-api/types": "0.1.4",
         "ansi-colors": "4.1.3",
         "cross-spawn": "7.0.6",
         "open": "11.0.0",
-        "semver": "7.7.3"
+        "semver": "7.8.4"
       },
       "engines": {
-        "node": ">=20.19.0"
+        "node": ">=22.18.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/hey-api"
@@ -5906,9 +5934,9 @@
       }
     },
     "node_modules/@hey-api/shared/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "license": "ISC",
       "peer": true,
       "bin": {
@@ -5919,9 +5947,9 @@
       }
     },
     "node_modules/@hey-api/spec-types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.1.0.tgz",
-      "integrity": "sha512-StS4RrAO5pyJCBwe6uF9MAuPflkztriW+FPnVb7oEjzDYv1sxPwP+f7fL6u6D+UVrKpZ/9bPNx/xXVdkeWPU6A==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@hey-api/spec-types/-/spec-types-0.2.0.tgz",
+      "integrity": "sha512-ibQ8Is7evMavzr8GNyJCcTg975d8DpaMUyLmOrQ85UBdy1l6t1KuRAwgChAbesJsIlNV6gjmlXruWyegDX18Fg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -5973,6 +6001,554 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "deprecated": "Use @eslint/object-schema instead",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
+      "cpu": [
+        "arm"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.11.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
     },
     "node_modules/@inquirer/external-editor": {
       "version": "1.0.3",
@@ -6635,6 +7211,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/@lukeed/ms": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@lukeed/ms/-/ms-2.0.2.tgz",
+      "integrity": "sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@lukeed/uuid": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
@@ -7167,15 +7753,15 @@
       }
     },
     "node_modules/@metamask/sdk/node_modules/engine.io-client": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
-      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.6.tgz",
+      "integrity": "sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
         "engine.io-parser": "~5.2.1",
-        "ws": "~8.18.3",
+        "ws": "~8.21.0",
         "xmlhttprequest-ssl": "~2.1.1"
       }
     },
@@ -7203,9 +7789,9 @@
       "license": "MIT"
     },
     "node_modules/@metamask/sdk/node_modules/engine.io-client/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -9812,9 +10398,9 @@
       }
     },
     "node_modules/@segment/analytics-next": {
-      "version": "1.84.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.84.0.tgz",
-      "integrity": "sha512-V5scoCrhiTpRPOuBwNVpvE4KvHwrjgQ5fs282R72KiAZ0HoxmjLgReZYjZogBf7qq/c6VmQG3nidwh8PQGcY1A==",
+      "version": "1.84.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-next/-/analytics-next-1.84.1.tgz",
+      "integrity": "sha512-jcwALgEc4DP6PG6oj0YS0yLiQL2R/N1NAgGGH50898/FNcXLyv/v8c+qoiHJxIpGm3qp8nJZTDeGe1z1Co2NzA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -9825,7 +10411,7 @@
         "@segment/analytics.js-video-plugins": "^0.2.1",
         "@segment/facade": "^3.4.9",
         "dset": "^3.1.4",
-        "js-cookie": "3.0.1",
+        "js-cookie": "^3.0.7",
         "node-fetch": "^2.6.7",
         "tslib": "^2.4.1",
         "unfetch": "^4.1.0"
@@ -11379,9 +11965,9 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket/node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -15291,9 +15877,9 @@
       }
     },
     "node_modules/@walletconnect/jsonrpc-ws-connection/node_modules/ws": {
-      "version": "7.5.10",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+      "integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.3.0"
@@ -17721,97 +18307,6 @@
       "license": "MIT",
       "peer": true
     },
-    "node_modules/bare-events": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
-      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
-      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.16.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-os": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
-      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "bare": ">=1.14.0"
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
-      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-os": "^3.0.1"
-      }
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
-      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.2.tgz",
-      "integrity": "sha512-/9a2j4ac6ckpmAHvod/ob7x439OAHst/drc2Clnq+reRYd/ovddwcF4LfoxHyNk5AuGBnPg+HqFjmE/Zpq6v0A==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
     "node_modules/base-x": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-5.0.1.tgz",
@@ -17988,9 +18483,9 @@
       "license": "MIT"
     },
     "node_modules/body-parser": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
-      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "version": "1.20.6",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+      "integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
       "license": "MIT",
       "dependencies": {
         "bytes": "~3.1.2",
@@ -18025,21 +18520,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "license": "MIT"
-    },
-    "node_modules/body-parser/node_modules/qs": {
-      "version": "6.15.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
-      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/boolbase": {
       "version": "1.0.0",
@@ -18076,9 +18556,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.17.tgz",
+      "integrity": "sha512-w+aeW/mkgM4PyRMOJCgi3fOrTm5Q8QY1OSfn2TO2iuDj3ezIHqejmuxbjfPrqUkgqRew1iqkyAn0tr0ZwHD9+w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -18309,24 +18789,24 @@
       }
     },
     "node_modules/c12": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.3.tgz",
-      "integrity": "sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/c12/-/c12-3.3.4.tgz",
+      "integrity": "sha512-cM0ApFQSBXuourJejzwv/AuPRvAxordTyParRVcHjjtXirtkzM0uK2L9TTn9s0cXZbG7E55jCivRQzoxYmRAlA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "chokidar": "^5.0.0",
-        "confbox": "^0.2.2",
-        "defu": "^6.1.4",
-        "dotenv": "^17.2.3",
+        "confbox": "^0.2.4",
+        "defu": "^6.1.6",
+        "dotenv": "^17.3.1",
         "exsolve": "^1.0.8",
-        "giget": "^2.0.0",
+        "giget": "^3.2.0",
         "jiti": "^2.6.1",
         "ohash": "^2.0.11",
         "pathe": "^2.0.3",
-        "perfect-debounce": "^2.0.0",
+        "perfect-debounce": "^2.1.0",
         "pkg-types": "^2.3.0",
-        "rc9": "^2.1.2"
+        "rc9": "^3.0.1"
       },
       "peerDependencies": {
         "magicast": "*"
@@ -19040,16 +19520,6 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/citty": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.1.6.tgz",
-      "integrity": "sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "consola": "^3.2.3"
-      }
-    },
     "node_modules/cjs-module-lexer": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
@@ -19442,19 +19912,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -19472,16 +19929,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -20623,9 +21070,9 @@
       }
     },
     "node_modules/dcl-catalyst-client": {
-      "version": "21.10.3",
-      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.10.3.tgz",
-      "integrity": "sha512-P3j+oSNwezqIN/MZtz0Ii8dmd5bTxziBqR2ifq4ZMydf016+MLSCwkexFZhz9wZ5eW0PN/bEOAcx4Rhx+xTcwg==",
+      "version": "21.11.0",
+      "resolved": "https://registry.npmjs.org/dcl-catalyst-client/-/dcl-catalyst-client-21.11.0.tgz",
+      "integrity": "sha512-6BgOCz4aYnMGtuIkXTLP3hjoZHLwoScTLvs73U4R8Um6lIsnKNsbn5UyaocVNpkgrzZWaTGHDsv36OZJNH3XTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@dcl/catalyst-contracts": "^4.4.0",
@@ -20680,13 +21127,13 @@
       "license": "ISC"
     },
     "node_modules/decentraland-connect": {
-      "version": "12.0.4",
-      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-12.0.4.tgz",
-      "integrity": "sha512-j4R9shgNH6+oS0T5+phvLWn+OxepyXGbvejg0lM9ur8RxULwV39YfWsDLf16cfmuXYda5LvkJSH4fBK4rmlbYg==",
+      "version": "12.1.1",
+      "resolved": "https://registry.npmjs.org/decentraland-connect/-/decentraland-connect-12.1.1.tgz",
+      "integrity": "sha512-+8eK55F3Gxs1cPe2v+Aw1SuSbXxVAqExRfrxC9ip5K5HgLXiiC5rYHFL56HOYjPklcUzw1+zne72S9HoLKNIXQ==",
       "dependencies": {
         "@dcl/schemas": "^22.1.0",
         "@magic-ext/oauth2": "15.3.2-canary.1040.22248562051.0",
-        "@reown/appkit": "^1.8.15",
+        "@reown/appkit": "^1.8.19",
         "@reown/appkit-adapter-wagmi": "^1.8.19",
         "@web3-react/fortmatic-connector": "^6.1.6",
         "@web3-react/injected-connector": "^6.0.7",
@@ -21992,9 +22439,9 @@
       }
     },
     "node_modules/decentraland-connect/node_modules/thirdweb": {
-      "version": "5.119.4",
-      "resolved": "https://registry.npmjs.org/thirdweb/-/thirdweb-5.119.4.tgz",
-      "integrity": "sha512-kWtpjtLaLehEi/v937cN3XeBIW6zM/PKgulFMdIEJsP960kLBeFHFAJaysLixkh2Jxd1JA2hlXNUrQbgIDsYfQ==",
+      "version": "5.120.1",
+      "resolved": "https://registry.npmjs.org/thirdweb/-/thirdweb-5.120.1.tgz",
+      "integrity": "sha512-AVAi0HBjIs58Tn9E/RDHO/E3MPlkcV0Xaf8tc3sZ8NO+vDOuOoub+6ZHW14K9piD1uELFvB52BoKgkYYof5Mzg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@base-org/account": "2.5.0",
@@ -22762,9 +23209,9 @@
       }
     },
     "node_modules/decentraland-ui2": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.7.0.tgz",
-      "integrity": "sha512-dRKsNGb5w/vIVpwqdHueSxGfD9tJZRY/lQGFR2sL8pFA1hzvsyeg5SAMHM3wPC98LJbH6V7K9DA107oXJ4+tnw==",
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/decentraland-ui2/-/decentraland-ui2-3.14.0.tgz",
+      "integrity": "sha512-Z07RvCtMGHNb34yaXxVlytM7h3J7edWO0Crz2WwrjiZvyurT8xsvF1gOs54In2lkzz1eNcEVUmG4OTbw9gv5Yw==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -22784,7 +23231,7 @@
       "peerDependencies": {
         "@contentful/rich-text-react-renderer": "^16.0.0",
         "@dcl/hooks": "^1.2.1",
-        "@dcl/schemas": "^26.0.0",
+        "@dcl/schemas": "^26.5.0",
         "@dcl/ui-env": "^2.0.0",
         "lottie-react": "^2.4.0",
         "react": "^18.2.0",
@@ -23495,15 +23942,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
       "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
-    },
-    "node_modules/dom7": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
-      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
-      "license": "MIT",
-      "dependencies": {
-        "ssr-window": "^4.0.0"
-      }
     },
     "node_modules/domelementtype": {
       "version": "1.3.1",
@@ -25539,15 +25977,6 @@
         "node": ">=0.4.x"
       }
     },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/eventsource": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -25618,15 +26047,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/expand-template": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "license": "(MIT OR WTFPL)",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/expect": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
@@ -25645,14 +26065,14 @@
       }
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -25671,7 +26091,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -25806,9 +26226,9 @@
       "license": "MIT"
     },
     "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.1.1.tgz",
+      "integrity": "sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==",
       "license": "MIT",
       "peer": true
     },
@@ -25895,12 +26315,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT"
-    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -25945,9 +26359,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",
@@ -25961,9 +26375,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
       "funding": [
         {
           "type": "github",
@@ -25972,7 +26386,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
       }
     },
     "node_modules/fast-xml-parser": {
@@ -26597,16 +27012,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -26741,12 +27156,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
     },
     "node_modules/fs-exists-cached": {
       "version": "1.0.0",
@@ -27340,21 +27749,6 @@
         "graphql": "^15.0.0"
       }
     },
-    "node_modules/gatsby-plugin-utils/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/gatsby-plugin-utils/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/gatsby-plugin-utils/node_modules/gatsby-sharp": {
       "version": "0.19.0",
       "resolved": "https://registry.npmjs.org/gatsby-sharp/-/gatsby-sharp-0.19.0.tgz",
@@ -27366,75 +27760,6 @@
       },
       "engines": {
         "node": ">=14.15.0"
-      }
-    },
-    "node_modules/gatsby-plugin-utils/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "license": "MIT"
-    },
-    "node_modules/gatsby-plugin-utils/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-plugin-utils/node_modules/sharp": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
-      "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^5.0.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.3.7",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/gatsby-plugin-utils/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/gatsby-plugin-utils/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/gatsby-react-router-scroll": {
@@ -27481,97 +27806,6 @@
       },
       "engines": {
         "node": ">=14.15.0"
-      }
-    },
-    "node_modules/gatsby-sharp/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC",
-      "optional": true
-    },
-    "node_modules/gatsby-sharp/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/gatsby-sharp/node_modules/node-addon-api": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
-      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/gatsby-sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/gatsby-sharp/node_modules/sharp": {
-      "version": "0.30.7",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.30.7.tgz",
-      "integrity": "sha512-G+MY2YW33jgflKPTXXptVO28HvNOo9G3j0MybYAHeEmby+QuD2U98dT6ueht9cv/XDqZspSpIhoSW+BAKJ7Hig==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.1",
-        "node-addon-api": "^5.0.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.3.7",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^2.1.1",
-        "tunnel-agent": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/libvips"
-      }
-    },
-    "node_modules/gatsby-sharp/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/gatsby-sharp/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/gatsby-telemetry": {
@@ -28086,7 +28320,6 @@
       "version": "4.14.0",
       "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
       "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "resolve-pkg-maps": "^1.0.0"
@@ -28096,19 +28329,11 @@
       }
     },
     "node_modules/giget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/giget/-/giget-2.0.0.tgz",
-      "integrity": "sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/giget/-/giget-3.3.1.tgz",
+      "integrity": "sha512-r+mvuDjrjMpsdw46Kmeydb8bdHm7wOKw8wNBtTndkjbPjgAp5oUJUxRE76wZFknxIPokfWvep2qSXK37aXE6zg==",
       "license": "MIT",
       "peer": true,
-      "dependencies": {
-        "citty": "^0.1.6",
-        "consola": "^3.4.0",
-        "defu": "^6.1.4",
-        "node-fetch-native": "^1.6.6",
-        "nypm": "^0.6.0",
-        "pathe": "^2.0.3"
-      },
       "bin": {
         "giget": "dist/cli.mjs"
       }
@@ -28122,12 +28347,6 @@
         "is-ssh": "^1.4.0",
         "parse-url": "^8.1.0"
       }
-    },
-    "node_modules/github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
     },
     "node_modules/gl-vec2": {
       "version": "1.3.0",
@@ -28176,9 +28395,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.3.tgz",
+      "integrity": "sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -28703,9 +28922,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -28794,9 +29013,9 @@
       "license": "MIT"
     },
     "node_modules/hono": {
-      "version": "4.12.16",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
-      "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
+      "version": "4.12.32",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
+      "integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -28946,9 +29165,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -31170,9 +31389,9 @@
       }
     },
     "node_modules/jiti": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
-      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
       "license": "MIT",
       "peer": true,
       "bin": {
@@ -31189,9 +31408,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -31230,14 +31449,11 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/js-cookie": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
-      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+      "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
       "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
+      "peer": true
     },
     "node_modules/js-sha3": {
       "version": "0.8.0",
@@ -31252,9 +31468,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -33454,12 +33670,6 @@
         "mkdirp": "bin/cmd.js"
       }
     },
-    "node_modules/mkdirp-classic": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
     "node_modules/moment": {
       "version": "2.30.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
@@ -33603,9 +33813,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -33619,12 +33829,6 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
-    },
-    "node_modules/napi-build-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
-      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
     },
     "node_modules/napi-postinstall": {
       "version": "0.3.4",
@@ -33700,30 +33904,6 @@
       "dependencies": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      }
-    },
-    "node_modules/node-abi": {
-      "version": "3.89.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
-      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/node-abi/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -34256,31 +34436,6 @@
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==",
       "license": "MIT"
-    },
-    "node_modules/nypm": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/nypm/-/nypm-0.6.6.tgz",
-      "integrity": "sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "citty": "^0.2.2",
-        "pathe": "^2.0.3",
-        "tinyexec": "^1.1.1"
-      },
-      "bin": {
-        "nypm": "dist/cli.mjs"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/nypm/node_modules/citty": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/citty/-/citty-0.2.2.tgz",
-      "integrity": "sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/obj-case": {
       "version": "0.2.1",
@@ -35194,9 +35349,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
       "funding": [
         {
           "type": "github",
@@ -35678,9 +35833,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.13",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
-      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "funding": [
         {
           "type": "opencollective",
@@ -35697,7 +35852,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -36319,76 +36474,6 @@
         "url": "https://opencollective.com/preact"
       }
     },
-    "node_modules/prebuild-install": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
-      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
-      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
-      "license": "MIT",
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^2.0.0",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/chownr": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
-    },
-    "node_modules/prebuild-install/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-fs": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
-      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.1.4"
-      }
-    },
-    "node_modules/prebuild-install/node_modules/tar-stream": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bl": "^4.0.3",
-        "end-of-stream": "^1.4.1",
-        "fs-constants": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -36612,10 +36697,13 @@
       "license": "MIT"
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
@@ -36725,12 +36813,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -36955,14 +37044,14 @@
       }
     },
     "node_modules/rc9": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/rc9/-/rc9-2.1.2.tgz",
-      "integrity": "sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/rc9/-/rc9-3.0.1.tgz",
+      "integrity": "sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "defu": "^6.1.4",
-        "destr": "^2.0.3"
+        "defu": "^6.1.6",
+        "destr": "^2.0.5"
       }
     },
     "node_modules/react": {
@@ -39086,26 +39175,52 @@
       "peer": true
     },
     "node_modules/sharp": {
-      "version": "0.32.6",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
-      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
-      "hasInstallScript": true,
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.2",
-        "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.1",
-        "semver": "^7.5.4",
-        "simple-get": "^4.0.1",
-        "tar-fs": "^3.0.4",
-        "tunnel-agent": "^0.6.0"
+        "@img/colour": "^1.1.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": ">=14.15.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/sharp/node_modules/detect-libc": {
@@ -39117,16 +39232,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/sharp/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "license": "MIT"
-    },
     "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -39157,9 +39266,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+      "integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -39169,14 +39278,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -39277,46 +39386,6 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "decompress-response": "^6.0.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/simple-swizzle/node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
     },
     "node_modules/simple-update-notifier": {
@@ -39637,12 +39706,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/ssr-window": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
-      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
-      "license": "MIT"
-    },
     "node_modules/st": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/st/-/st-2.0.0.tgz",
@@ -39772,17 +39835,6 @@
       "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/streamx": {
-      "version": "2.25.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
-      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -40271,9 +40323,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.2.tgz",
-      "integrity": "sha512-TyzE4NVGLUFy+H/Uy4N6c3G0HEeprsVfge6Lmq+0FdQQ/zqoVYB62IsBZORsiL+o96s6ff/V6/3UQo/C0cgCAA==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-2.8.3.tgz",
+      "integrity": "sha512-5EZD0pafXX6PphdwOGCiVLDSaV1xyuQao2blHajHLsPxr07q4mmEjdtXEWgG07ae2mIz8Ex2CDXNCTiXhy3Khw==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
@@ -40423,25 +40475,20 @@
       }
     },
     "node_modules/swiper": {
-      "version": "8.4.7",
-      "resolved": "https://registry.npmjs.org/swiper/-/swiper-8.4.7.tgz",
-      "integrity": "sha512-VwO/KU3i9IV2Sf+W2NqyzwWob4yX9Qdedq6vBtS0rFqJ6Fa5iLUJwxQkuD4I38w0WDJwmFl8ojkdcRFPHWD+2g==",
+      "version": "12.2.0",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-12.2.0.tgz",
+      "integrity": "sha512-K8uXsBZU6ME97Ia3xbBge8IRCnR1lOmIILzvY/jGVic7dSTQ530s3uO8RvXbPUtkkXLWIwmZLRPbtDxRWVAFdg==",
       "funding": [
         {
-          "type": "patreon",
-          "url": "https://www.patreon.com/swiperjs"
+          "type": "custom",
+          "url": "https://sponsors.nolimits4web.com"
         },
         {
-          "type": "open_collective",
-          "url": "http://opencollective.com/swiper"
+          "type": "github",
+          "url": "https://github.com/sponsors/nolimits4web"
         }
       ],
-      "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "dom7": "^4.0.4",
-        "ssr-window": "^4.0.2"
-      },
       "engines": {
         "node": ">= 4.7.0"
       }
@@ -40502,9 +40549,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
-      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -40515,46 +40562,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/tar-fs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
-      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0",
-        "tar-stream": "^3.1.5"
-      },
-      "optionalDependencies": {
-        "bare-fs": "^4.0.1",
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/tar-stream/node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
       }
     },
     "node_modules/tar/node_modules/minipass": {
@@ -40582,15 +40589,6 @@
       "license": "MIT",
       "dependencies": {
         "bintrees": "1.0.2"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
       }
     },
     "node_modules/term-size": {
@@ -40759,29 +40757,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
-    "node_modules/text-decoder/node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -40837,16 +40812,6 @@
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
     },
-    "node_modules/tinyexec": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
-      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -40874,9 +40839,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -41257,18 +41222,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "license": "0BSD"
     },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
@@ -41505,9 +41458,9 @@
       "license": "MIT"
     },
     "node_modules/ua-parser-js": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.9.tgz",
-      "integrity": "sha512-OsqGhxyo/wGdLSXMSJxuMGN6H4gDnKz6Fb3IBm4bxZFMnyy0sdf6MN96Ie8tC6z/btdO+Bsy8guxlvLdwT076w==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
+      "integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
       "funding": [
         {
           "type": "opencollective",
@@ -42502,9 +42455,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.48.7",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.7.tgz",
-      "integrity": "sha512-auLZcv/FtIeuqtDcW4Kdhw4NeRPWgLUcWSO5oz4tG6UE4/bHOBHEfm0TtLV+/j71r5MM/eURvFiYzjYVayrExA==",
+      "version": "2.55.10",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.55.10.tgz",
+      "integrity": "sha512-Q9Ba+/ma81U2M5o5P2AQ7Ux8rTIwmCZvUcr8rKdQ22bV0IBFHllM2m5gWDP8hFaUN2nH2oW3QG44amRazflYNQ==",
       "funding": [
         {
           "type": "github",
@@ -42519,8 +42472,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.20",
-        "ws": "8.18.3"
+        "ox": "0.14.33",
+        "ws": "8.21.0"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -42607,9 +42560,9 @@
       }
     },
     "node_modules/viem/node_modules/ox": {
-      "version": "0.14.20",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.20.tgz",
-      "integrity": "sha512-rby38C3nDn8eQkf29Zgw4hkCZJ64Qqi0zRPWL8ENUQ7JVuoITqrVtwWQgM/He19SCMUEc7hS/Sjw0jIOSLJhOw==",
+      "version": "0.14.33",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.33.tgz",
+      "integrity": "sha512-rooA/4o7bBof4Ge2VH/eovfNPb/AEEYyrNj03wggc55g5HZD8Pjs/OeWhttgjic3dDcqn0r29bDuvQEdTiUemQ==",
       "funding": [
         {
           "type": "github",
@@ -42637,9 +42590,9 @@
       }
     },
     "node_modules/viem/node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -44711,6 +44664,21 @@
       "license": "MIT",
       "dependencies": {
         "cookiejar": "^2.1.1"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xml2js": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "version": "0.0.0-development",
   "author": "",
   "engines": {
-    "node": "18.*",
-    "npm": "8.* || 9.*"
+    "node": "24.*",
+    "npm": "10.* || 11.*"
   },
   "dependencies": {
     "@dcl/schemas": "^25.0.0",
@@ -50,7 +50,9 @@
     "typescript": "^5.9.3"
   },
   "overrides": {
-    "@dcl/schemas": "^25.0.0"
+    "@dcl/schemas": "^25.0.0",
+    "sharp": "^0.35.3",
+    "swiper": "^12.1.2"
   },
   "license": "MIT",
   "scripts": {

--- a/src/entities/Destination/routes/index.ts
+++ b/src/entities/Destination/routes/index.ts
@@ -1,4 +1,3 @@
-import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCors"
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
@@ -8,23 +7,6 @@ import { getDestinationsListById } from "./getDestinationsListById"
 export const DECENTRALAND_URL = env("DECENTRALAND_URL", "")
 
 export default routes((router) => {
-  router.getRouter().use(
-    withCors({
-      corsOrigin: [
-        /https?:\/\/localhost(:\d{4,6})?/,
-        /https?:\/\/127\.0\.0\.1(:\d{4,6})?/,
-        /https?:\/\/192\.168\.\d{1,3}\.\d{1,3}(:\d{4,6})?/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*dcl\.gg/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.systems/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.today/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.zone/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.org/,
-        /https:\/\/decentraland\.github\.io/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*pages\.dev/,
-        /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
-      ],
-    })
-  )
   router.get("/destinations", getDestinationsList)
   router.post("/destinations", getDestinationsListById)
 }, {})

--- a/src/entities/Map/routes/index.ts
+++ b/src/entities/Map/routes/index.ts
@@ -1,4 +1,3 @@
-import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCors"
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
@@ -8,23 +7,6 @@ import { getMapPlaces } from "./getMapPlaces"
 export const DECENTRALAND_URL = env("DECENTRALAND_URL", "")
 
 export default routes((router) => {
-  router.getRouter().use(
-    withCors({
-      corsOrigin: [
-        /https?:\/\/localhost(:\d{4,6})?/,
-        /https?:\/\/127\.0\.0\.1(:\d{4,6})?/,
-        /https?:\/\/192\.168\.\d{1,3}\.\d{1,3}(:\d{4,6})?/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*dcl\.gg/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.systems/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.today/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.zone/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.org/,
-        /https:\/\/decentraland\.github\.io/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*pages\.dev/,
-        /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
-      ],
-    })
-  )
   router.get("/map", getMapPlaces)
   // This new endpoint will merge the places and worlds content
   router.get("/map/places", getAllPlacesList)

--- a/src/entities/Place/model.test.ts
+++ b/src/entities/Place/model.test.ts
@@ -5,6 +5,7 @@ import { hotSceneGenesisPlaza } from "../../__data__/hotSceneGenesisPlaza"
 import { placeGenesisPlaza } from "../../__data__/placeGenesisPlaza"
 import { placeGenesisPlazaWithAggregatedAttributes } from "../../__data__/placeGenesisPlazaWithAggregatedAttributes"
 import { worldPlaceParalax } from "../../__data__/world"
+import { PlaceContentRatingAttributes } from "../PlaceContentRating/types"
 
 const placesAttributes: Array<keyof PlaceAttributes> = [
   "title",
@@ -734,6 +735,53 @@ describe(`updateLikes`, () => {
         .trim()
         .replace(/\s{2,}/gi, " ")
     )
+  })
+})
+
+describe("updateRatingWithAudit", () => {
+  let audit: PlaceContentRatingAttributes
+  let place: Pick<PlaceAttributes, "id" | "world" | "base_position">
+
+  beforeEach(() => {
+    audit = {
+      id: "96be5815-95f8-4ed2-9dd1-3f4f2b90ac5c",
+      entity_id: placeGenesisPlaza.id,
+      original_rating: placeGenesisPlaza.content_rating,
+      update_rating: "T",
+      moderator: "0x1234567890123456789012345678901234567890",
+      comment: "Reviewed by moderation",
+      created_at: new Date("2026-07-29T00:00:00.000Z"),
+    }
+    place = {
+      id: placeGenesisPlaza.id,
+      world: false,
+      base_position: placeGenesisPlaza.base_position,
+    }
+  })
+
+  describe("when eligible place rows are updated", () => {
+    beforeEach(() => {
+      namedQuery.mockResolvedValue([{ updated_count: 2 }])
+    })
+
+    it("should return the affected row count", async () => {
+      await expect(
+        PlaceModel.updateRatingWithAudit(place, audit)
+      ).resolves.toBe(2)
+    })
+  })
+
+  describe("when no eligible world row remains", () => {
+    beforeEach(() => {
+      place = { ...place, world: true }
+      namedQuery.mockResolvedValue([])
+    })
+
+    it("should return zero", async () => {
+      await expect(
+        PlaceModel.updateRatingWithAudit(place, audit)
+      ).resolves.toBe(0)
+    })
   })
 })
 

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -573,7 +573,7 @@ export default class PlaceModel extends Model<PlaceAttributes> {
   static async updateRatingWithAudit(
     place: Pick<PlaceAttributes, "id" | "world" | "base_position">,
     audit: PlaceContentRatingAttributes
-  ): Promise<void> {
+  ): Promise<number> {
     const sql = SQL`
       WITH updated_places AS (
         UPDATE ${table(this)}
@@ -591,21 +591,30 @@ export default class PlaceModel extends Model<PlaceAttributes> {
           SQL`world is true AND "id" = ${place.id} AND ("disabled" IS FALSE OR "disabled_reason" = 'opt_out')`
         )}
         RETURNING "id"
+      ),
+      inserted_audit AS (
+        INSERT INTO ${table(PlaceContentRatingModel)}
+          ("id", "entity_id", "original_rating", "update_rating", "moderator", "comment", "created_at")
+        SELECT
+          ${audit.id},
+          ${audit.entity_id},
+          ${audit.original_rating},
+          ${audit.update_rating},
+          ${audit.moderator},
+          ${audit.comment},
+          ${audit.created_at}
+        WHERE EXISTS (SELECT 1 FROM updated_places)
+        RETURNING "entity_id"
       )
-      INSERT INTO ${table(PlaceContentRatingModel)}
-        ("id", "entity_id", "original_rating", "update_rating", "moderator", "comment", "created_at")
-      SELECT
-        ${audit.id},
-        ${audit.entity_id},
-        ${audit.original_rating},
-        ${audit.update_rating},
-        ${audit.moderator},
-        ${audit.comment},
-        ${audit.created_at}
-      WHERE EXISTS (SELECT 1 FROM updated_places)
+      SELECT COUNT(*)::int AS "updated_count"
+      FROM updated_places
     `
 
-    await this.namedQuery("update_rating_with_audit", sql)
+    const [result] = await this.namedQuery<{ updated_count: number }>(
+      "update_rating_with_audit",
+      sql
+    )
+    return result?.updated_count ?? 0
   }
 
   static async findWithHotScenes(

--- a/src/entities/Place/model.ts
+++ b/src/entities/Place/model.ts
@@ -37,6 +37,8 @@ import {
   FindAllPlacesWithAggregatesOptions,
 } from "../Map/types"
 import PlaceCategories from "../PlaceCategories/model"
+import PlaceContentRatingModel from "../PlaceContentRating/model"
+import { PlaceContentRatingAttributes } from "../PlaceContentRating/types"
 import PlacePositionModel from "../PlacePosition/model"
 import {
   MIN_USER_ACTIVITY,
@@ -566,6 +568,44 @@ export default class PlaceModel extends Model<PlaceAttributes> {
   static async updateLikes(placeId: string) {
     const sql = buildUpdateLikesQuery(this, placeId)
     return this.namedQuery("update_likes", sql)
+  }
+
+  static async updateRatingWithAudit(
+    place: Pick<PlaceAttributes, "id" | "world" | "base_position">,
+    audit: PlaceContentRatingAttributes
+  ): Promise<void> {
+    const sql = SQL`
+      WITH updated_places AS (
+        UPDATE ${table(this)}
+        SET "content_rating" = ${audit.update_rating}
+        WHERE ${conditional(
+          !place.world,
+          SQL`disabled is false AND world is false AND "base_position" IN (
+            SELECT DISTINCT("base_position")
+            FROM ${table(PlacePositionModel)} "pp"
+            WHERE "pp"."position" = ${place.base_position}
+          )`
+        )}
+        ${conditional(
+          place.world,
+          SQL`world is true AND "id" = ${place.id} AND ("disabled" IS FALSE OR "disabled_reason" = 'opt_out')`
+        )}
+        RETURNING "id"
+      )
+      INSERT INTO ${table(PlaceContentRatingModel)}
+        ("id", "entity_id", "original_rating", "update_rating", "moderator", "comment", "created_at")
+      SELECT
+        ${audit.id},
+        ${audit.entity_id},
+        ${audit.original_rating},
+        ${audit.update_rating},
+        ${audit.moderator},
+        ${audit.comment},
+        ${audit.created_at}
+      WHERE EXISTS (SELECT 1 FROM updated_places)
+    `
+
+    await this.namedQuery("update_rating_with_audit", sql)
   }
 
   static async findWithHotScenes(

--- a/src/entities/Place/routes/index.ts
+++ b/src/entities/Place/routes/index.ts
@@ -1,4 +1,3 @@
-import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCors"
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
@@ -12,16 +11,10 @@ import { updateDisabled } from "./updateDisabled"
 import { updateHighlight } from "./updateHighlight"
 import { updateRanking } from "./updateRanking"
 import { updateRating } from "./updateRating"
-import { API_CORS_ORIGINS } from "../../shared/cors"
 
 export const DECENTRALAND_URL = env("DECENTRALAND_URL", "")
 
 export default routes((router) => {
-  router.getRouter().use(
-    withCors({
-      corsOrigin: API_CORS_ORIGINS,
-    })
-  )
   router.get("/places/:place_id", getPlace)
   router.get("/places", getPlaceList)
   router.post("/places", getPlaceListById)

--- a/src/entities/Place/routes/index.ts
+++ b/src/entities/Place/routes/index.ts
@@ -12,25 +12,14 @@ import { updateDisabled } from "./updateDisabled"
 import { updateHighlight } from "./updateHighlight"
 import { updateRanking } from "./updateRanking"
 import { updateRating } from "./updateRating"
+import { API_CORS_ORIGINS } from "../../shared/cors"
 
 export const DECENTRALAND_URL = env("DECENTRALAND_URL", "")
 
 export default routes((router) => {
   router.getRouter().use(
     withCors({
-      corsOrigin: [
-        /https?:\/\/localhost(:\d{4,6})?/,
-        /https?:\/\/127\.0\.0\.1(:\d{4,6})?/,
-        /https?:\/\/192\.168\.\d{1,3}\.\d{1,3}(:\d{4,6})?/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*dcl\.gg/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.systems/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.today/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.zone/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.org/,
-        /https:\/\/decentraland\.github\.io/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*pages\.dev/,
-        /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
-      ],
+      corsOrigin: API_CORS_ORIGINS,
     })
   )
   router.get("/places/:place_id", getPlace)

--- a/src/entities/Place/routes/updateRating.test.ts
+++ b/src/entities/Place/routes/updateRating.test.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "crypto"
 import isAdmin from "decentraland-gatsby/dist/entities/Auth/isAdmin"
 import * as decentralandAuth from "decentraland-gatsby/dist/entities/Auth/routes/withDecentralandAuth"
 import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+import Response from "decentraland-gatsby/dist/entities/Route/wkc/response/Response"
 import { SceneContentRating } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 
 import { placeGenesisPlazaWithAggregatedAttributes } from "../../../__data__/placeGenesisPlazaWithAggregatedAttributes"
@@ -20,13 +21,16 @@ describe("place rating updates", () => {
   describe("when an administrator updates a place rating", () => {
     let placeId: string
     let request: Request
-    let resolveUpdate: () => void
-    let updatePromise: Promise<void>
+    let resolveUpdate: (updatedCount: number) => void
+    let updatePromise: Promise<number>
+    let updateRatingWithAuditMock: jest.SpiedFunction<
+      typeof PlaceModel.updateRatingWithAudit
+    >
 
     beforeEach(() => {
       placeId = randomUUID()
       request = new Request("http://0.0.0.0/", { method: "PUT" })
-      updatePromise = new Promise<void>((resolve) => {
+      updatePromise = new Promise<number>((resolve) => {
         resolveUpdate = resolve
       })
 
@@ -40,7 +44,7 @@ describe("place rating updates", () => {
         id: placeId,
         content_rating: SceneContentRating.EVERYONE,
       })
-      jest
+      updateRatingWithAuditMock = jest
         .spyOn(PlaceModel, "updateRatingWithAudit")
         .mockReturnValue(updatePromise)
     })
@@ -56,10 +60,28 @@ describe("place rating updates", () => {
         Promise.resolve("pending"),
       ])
 
-      resolveUpdate()
+      resolveUpdate(1)
       await responsePromise
 
       expect(state).toBe("pending")
+    })
+
+    describe("and no eligible database row remains", () => {
+      beforeEach(() => {
+        updateRatingWithAuditMock.mockResolvedValueOnce(0)
+      })
+
+      it("should respond with a conflict", async () => {
+        const responsePromise = updateRating({
+          request,
+          params: { place_id: placeId },
+          body: { content_rating: "T" },
+        })
+
+        await expect(responsePromise).rejects.toMatchObject({
+          status: Response.Conflict,
+        })
+      })
     })
   })
 })

--- a/src/entities/Place/routes/updateRating.test.ts
+++ b/src/entities/Place/routes/updateRating.test.ts
@@ -1,0 +1,65 @@
+import { randomUUID } from "crypto"
+
+import isAdmin from "decentraland-gatsby/dist/entities/Auth/isAdmin"
+import * as decentralandAuth from "decentraland-gatsby/dist/entities/Auth/routes/withDecentralandAuth"
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+import { SceneContentRating } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
+
+import { placeGenesisPlazaWithAggregatedAttributes } from "../../../__data__/placeGenesisPlazaWithAggregatedAttributes"
+import PlaceModel from "../model"
+import { updateRating } from "./updateRating"
+
+jest.mock("decentraland-gatsby/dist/entities/Auth/isAdmin")
+jest.mock("../../Slack/utils")
+
+describe("place rating updates", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe("when an administrator updates a place rating", () => {
+    let placeId: string
+    let request: Request
+    let resolveUpdate: () => void
+    let updatePromise: Promise<void>
+
+    beforeEach(() => {
+      placeId = randomUUID()
+      request = new Request("http://0.0.0.0/", { method: "PUT" })
+      updatePromise = new Promise<void>((resolve) => {
+        resolveUpdate = resolve
+      })
+
+      jest.spyOn(decentralandAuth, "withAuth").mockResolvedValue({
+        address: "0x1234567890123456789012345678901234567890",
+        metadata: {},
+      })
+      jest.mocked(isAdmin).mockReturnValue(true)
+      jest.spyOn(PlaceModel, "findByIdWithAggregates").mockResolvedValue({
+        ...placeGenesisPlazaWithAggregatedAttributes,
+        id: placeId,
+        content_rating: SceneContentRating.EVERYONE,
+      })
+      jest
+        .spyOn(PlaceModel, "updateRatingWithAudit")
+        .mockReturnValue(updatePromise)
+    })
+
+    it("should wait for the atomic database write before responding", async () => {
+      const responsePromise = updateRating({
+        request,
+        params: { place_id: placeId },
+        body: { content_rating: "T" },
+      })
+      const state = await Promise.race([
+        responsePromise.then(() => "resolved"),
+        Promise.resolve("pending"),
+      ])
+
+      resolveUpdate()
+      await responsePromise
+
+      expect(state).toBe("pending")
+    })
+  })
+})

--- a/src/entities/Place/routes/updateRating.ts
+++ b/src/entities/Place/routes/updateRating.ts
@@ -54,7 +54,7 @@ export async function updateRating(
   }
 
   const newPlace = { ...place, content_rating: body.content_rating }
-  await PlaceModel.updateRatingWithAudit(place, {
+  const updatedCount = await PlaceModel.updateRatingWithAudit(place, {
     id: randomUUID(),
     entity_id: place.id,
     original_rating: place.content_rating,
@@ -63,6 +63,13 @@ export async function updateRating(
     comment: body.comment || null,
     created_at: new Date(),
   })
+
+  if (updatedCount === 0) {
+    throw new ErrorResponse(
+      Response.Conflict,
+      `Place "${params.place_id}" could not be updated`
+    )
+  }
 
   if (
     place.content_rating &&

--- a/src/entities/Place/routes/updateRating.ts
+++ b/src/entities/Place/routes/updateRating.ts
@@ -10,7 +10,6 @@ import { AjvObjectSchema } from "decentraland-gatsby/dist/entities/Schema/types"
 import { SceneContentRating } from "decentraland-gatsby/dist/utils/api/Catalyst.types"
 
 import { isUpgradingRating } from "../../../utils/rating/contentRating"
-import PlaceContentRatingModel from "../../PlaceContentRating/model"
 import { createWkcValidator } from "../../shared/validate"
 import { notifyUpgradingRating } from "../../Slack/utils"
 import PlaceModel from "../model"
@@ -55,18 +54,15 @@ export async function updateRating(
   }
 
   const newPlace = { ...place, content_rating: body.content_rating }
-  Promise.all([
-    PlaceModel.updatePlace(newPlace, ["content_rating"]),
-    PlaceContentRatingModel.create({
-      id: randomUUID(),
-      entity_id: place.id,
-      original_rating: place.content_rating,
-      update_rating: body.content_rating,
-      moderator: userAuth.address,
-      comment: body.comment || null,
-      created_at: new Date(),
-    }),
-  ])
+  await PlaceModel.updateRatingWithAudit(place, {
+    id: randomUUID(),
+    entity_id: place.id,
+    original_rating: place.content_rating,
+    update_rating: body.content_rating,
+    moderator: userAuth.address,
+    comment: body.comment || null,
+    created_at: new Date(),
+  })
 
   if (
     place.content_rating &&
@@ -75,7 +71,7 @@ export async function updateRating(
       place.content_rating as SceneContentRating
     )
   ) {
-    notifyUpgradingRating(place, "Content Moderator", body.content_rating)
+    await notifyUpgradingRating(place, "Content Moderator", body.content_rating)
   }
 
   return new ApiResponse(newPlace)

--- a/src/entities/Report/routes.test.ts
+++ b/src/entities/Report/routes.test.ts
@@ -1,4 +1,13 @@
-import { REPORT_MAX_FILE_SIZE, createReportPostPolicy } from "./routes"
+import AWS from "aws-sdk"
+import * as decentralandAuth from "decentraland-gatsby/dist/entities/Auth/routes/withDecentralandAuth"
+import { Request } from "decentraland-gatsby/dist/entities/Route/wkc/request/Request"
+
+import {
+  REPORT_MAX_FILE_SIZE,
+  createLegacyReportPutParams,
+  createReportPostPolicy,
+  getSignedUrl,
+} from "./routes"
 
 describe("report upload policy", () => {
   afterEach(() => {
@@ -28,6 +37,10 @@ describe("report upload policy", () => {
       ])
     })
 
+    it("should bind the policy to the generated object key", () => {
+      expect(policy.Conditions).toContainEqual({ key: filename })
+    })
+
     it("should require private object access", () => {
       expect(policy.Fields).toMatchObject({ acl: "private" })
     })
@@ -36,6 +49,105 @@ describe("report upload policy", () => {
       expect(policy.Fields).toMatchObject({
         "x-amz-meta-address": address,
       })
+    })
+  })
+})
+
+describe("legacy report upload compatibility", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("when PUT parameters are created for an authenticated wallet", () => {
+    let address: string
+    let filename: string
+    let params: ReturnType<typeof createLegacyReportPutParams>
+
+    beforeEach(() => {
+      address = "0x1234567890123456789012345678901234567890"
+      filename = "550e8400-e29b-41d4-a716-446655440000.json"
+      params = createLegacyReportPutParams(address, filename)
+    })
+
+    it("should bind the signed PUT to the generated object key", () => {
+      expect(params.Key).toBe(filename)
+    })
+
+    it("should expire after sixty seconds", () => {
+      expect(params.Expires).toBe(60)
+    })
+
+    it("should prevent report caching", () => {
+      expect(params.CacheControl).toBe("no-store")
+    })
+  })
+})
+
+describe("report upload response", () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  describe("when an authenticated client requests upload credentials", () => {
+    let address: string
+    let request: Request
+    let response: Awaited<ReturnType<typeof getSignedUrl>>
+    let legacyPutUrl: string
+    let postUrl: string
+    let postFields: AWS.S3.PresignedPost.Fields
+    let putKey: string
+    let postKey: string
+    let getSignedUrlMock: jest.SpiedFunction<AWS.S3["getSignedUrl"]>
+    let createPresignedPostMock: jest.SpiedFunction<
+      AWS.S3["createPresignedPost"]
+    >
+
+    beforeEach(async () => {
+      address = "0x1234567890123456789012345678901234567890"
+      request = new Request("http://0.0.0.0/api/report", { method: "POST" })
+      legacyPutUrl =
+        "https://reports.s3.amazonaws.com/report.json?X-Amz-Signature=legacy"
+      postUrl = "https://reports.s3.amazonaws.com"
+      postFields = {
+        key: "report.json",
+        Policy: "signed-policy",
+        "X-Amz-Signature": "post-signature",
+      }
+
+      jest.spyOn(decentralandAuth, "withAuth").mockResolvedValue({
+        address,
+        metadata: {},
+      })
+      getSignedUrlMock = jest
+        .spyOn(AWS.S3.prototype, "getSignedUrl")
+        .mockReturnValue(legacyPutUrl)
+      createPresignedPostMock = jest
+        .spyOn(AWS.S3.prototype, "createPresignedPost")
+        .mockReturnValue({
+          url: postUrl,
+          fields: postFields,
+        })
+
+      response = await getSignedUrl({ request, params: {} })
+      putKey = getSignedUrlMock.mock.calls[0][1].Key
+      postKey = createPresignedPostMock.mock.calls[0][0].Fields?.key || ""
+    })
+
+    it("should keep signed_url compatible with legacy PUT clients", () => {
+      expect(response.body.data.signed_url).toBe(legacyPutUrl)
+    })
+
+    it("should return a self-describing constrained POST upload", () => {
+      expect(response.body.data.upload).toEqual({
+        method: "POST",
+        url: `${postUrl}/`,
+        fields: postFields,
+        max_file_size: REPORT_MAX_FILE_SIZE,
+      })
+    })
+
+    it("should bind PUT and POST credentials to the same object key", () => {
+      expect(putKey).toBe(postKey)
     })
   })
 })

--- a/src/entities/Report/routes.test.ts
+++ b/src/entities/Report/routes.test.ts
@@ -1,0 +1,41 @@
+import { REPORT_MAX_FILE_SIZE, createReportPostPolicy } from "./routes"
+
+describe("report upload policy", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe("when a policy is created for an authenticated wallet", () => {
+    let address: string
+    let filename: string
+    let policy: ReturnType<typeof createReportPostPolicy>
+
+    beforeEach(() => {
+      address = "0x1234567890123456789012345678901234567890"
+      filename = "550e8400-e29b-41d4-a716-446655440000.json"
+      policy = createReportPostPolicy(address, filename)
+    })
+
+    it("should expire after sixty seconds", () => {
+      expect(policy.Expires).toBe(60)
+    })
+
+    it("should enforce the report size limit", () => {
+      expect(policy.Conditions).toContainEqual([
+        "content-length-range",
+        1,
+        REPORT_MAX_FILE_SIZE,
+      ])
+    })
+
+    it("should require private object access", () => {
+      expect(policy.Fields).toMatchObject({ acl: "private" })
+    })
+
+    it("should bind the policy to the authenticated wallet", () => {
+      expect(policy.Fields).toMatchObject({
+        "x-amz-meta-address": address,
+      })
+    })
+  })
+})

--- a/src/entities/Report/routes.ts
+++ b/src/entities/Report/routes.ts
@@ -15,12 +15,30 @@ const ACCESS_SECRET = env("AWS_ACCESS_SECRET")
 const BUCKET_HOSTNAME = env("BUCKET_HOSTNAME")
 const BUCKET_NAME = env("AWS_BUCKET_NAME", "")
 export const REPORT_MAX_FILE_SIZE = 1024 * 1024
-const SIGNED_POST_EXPIRES_SECONDS = 60
+const SIGNED_UPLOAD_EXPIRES_SECONDS = 60
 
 const s3 = new AWS.S3({
   accessKeyId: ACCESS_KEY,
   secretAccessKey: ACCESS_SECRET,
 })
+
+export type ReportUploadResponse = {
+  /**
+   * @deprecated Temporary PUT compatibility URL for clients that have not
+   * migrated to the constrained multipart POST upload.
+   */
+  signed_url: string
+  upload: {
+    method: "POST"
+    url: string
+    fields: Record<string, string>
+    max_file_size: number
+  }
+}
+
+export type LegacyReportPutParams = Omit<AWS.S3.PutObjectRequest, "Expires"> & {
+  Expires: number
+}
 
 export function createReportPostPolicy(
   address: string,
@@ -29,7 +47,7 @@ export function createReportPostPolicy(
   const mimetype = "application/json"
   return {
     Bucket: BUCKET_NAME,
-    Expires: SIGNED_POST_EXPIRES_SECONDS,
+    Expires: SIGNED_UPLOAD_EXPIRES_SECONDS,
     Fields: {
       key: filename,
       "Content-Type": mimetype,
@@ -39,11 +57,27 @@ export function createReportPostPolicy(
     },
     Conditions: [
       ["content-length-range", 1, REPORT_MAX_FILE_SIZE],
+      { key: filename },
       { "Content-Type": mimetype },
       { acl: "private" },
       { "Cache-Control": "no-store" },
       { "x-amz-meta-address": address },
     ],
+  }
+}
+
+export function createLegacyReportPutParams(
+  address: string,
+  filename: string
+): LegacyReportPutParams {
+  return {
+    Bucket: BUCKET_NAME,
+    Key: filename,
+    Expires: SIGNED_UPLOAD_EXPIRES_SECONDS,
+    ContentType: "application/json",
+    ACL: "private",
+    CacheControl: "no-store",
+    Metadata: { address },
   }
 }
 
@@ -53,40 +87,45 @@ export default routes((router) => {
 
 export async function getSignedUrl(
   ctx: Context<{}, "request" | "params">
-): Promise<
-  ApiResponse<{
-    signed_url: string
-    fields: Record<string, string>
-    max_file_size: number
-  }>
-> {
+): Promise<ApiResponse<ReportUploadResponse>> {
   const userAuth = await withAuth(ctx)
   const ext = extension("application/json")
   const filename = `${randomUUID()}${ext}`
 
-  const signedUrl = await retry({ times: 10, delay: 100 }, async () => {
+  const signedUploads = await retry({ times: 10, delay: 100 }, async () => {
+    const legacyPutUrl = new URL(
+      s3.getSignedUrl(
+        "putObject",
+        createLegacyReportPutParams(userAuth.address, filename)
+      )
+    )
     const presignedPost = s3.createPresignedPost(
       createReportPostPolicy(userAuth.address, filename)
     )
-
-    const url = new URL(presignedPost.url)
-    if (!presignedPost.fields.Policy) {
+    const postUrl = new URL(presignedPost.url)
+    if (legacyPutUrl.searchParams.size === 0 || !presignedPost.fields.Policy) {
       throw new Error("Invalid AWS response")
     }
 
     if (BUCKET_HOSTNAME) {
-      url.hostname = BUCKET_HOSTNAME
+      legacyPutUrl.hostname = BUCKET_HOSTNAME
+      postUrl.hostname = BUCKET_HOSTNAME
     }
 
     return {
-      url: url.toString(),
-      fields: presignedPost.fields,
+      legacyPutUrl: legacyPutUrl.toString(),
+      postUrl: postUrl.toString(),
+      postFields: presignedPost.fields,
     }
   })
 
   return new ApiResponse({
-    signed_url: signedUrl.url,
-    fields: signedUrl.fields,
-    max_file_size: REPORT_MAX_FILE_SIZE,
+    signed_url: signedUploads.legacyPutUrl,
+    upload: {
+      method: "POST",
+      url: signedUploads.postUrl,
+      fields: signedUploads.postFields,
+      max_file_size: REPORT_MAX_FILE_SIZE,
+    },
   })
 }

--- a/src/entities/Report/routes.ts
+++ b/src/entities/Report/routes.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "crypto"
+
 import AWS from "aws-sdk"
 import { withAuth } from "decentraland-gatsby/dist/entities/Auth/routes/withDecentralandAuth"
 import Context from "decentraland-gatsby/dist/entities/Route/wkc/context/Context"
@@ -12,11 +14,38 @@ const ACCESS_KEY = env("AWS_ACCESS_KEY")
 const ACCESS_SECRET = env("AWS_ACCESS_SECRET")
 const BUCKET_HOSTNAME = env("BUCKET_HOSTNAME")
 const BUCKET_NAME = env("AWS_BUCKET_NAME", "")
+export const REPORT_MAX_FILE_SIZE = 1024 * 1024
+const SIGNED_POST_EXPIRES_SECONDS = 60
 
 const s3 = new AWS.S3({
   accessKeyId: ACCESS_KEY,
   secretAccessKey: ACCESS_SECRET,
 })
+
+export function createReportPostPolicy(
+  address: string,
+  filename: string
+): AWS.S3.PresignedPost.Params {
+  const mimetype = "application/json"
+  return {
+    Bucket: BUCKET_NAME,
+    Expires: SIGNED_POST_EXPIRES_SECONDS,
+    Fields: {
+      key: filename,
+      "Content-Type": mimetype,
+      acl: "private",
+      "Cache-Control": "no-store",
+      "x-amz-meta-address": address,
+    },
+    Conditions: [
+      ["content-length-range", 1, REPORT_MAX_FILE_SIZE],
+      { "Content-Type": mimetype },
+      { acl: "private" },
+      { "Cache-Control": "no-store" },
+      { "x-amz-meta-address": address },
+    ],
+  }
+}
 
 export default routes((router) => {
   router.post("/report", getSignedUrl)
@@ -24,36 +53,24 @@ export default routes((router) => {
 
 export async function getSignedUrl(
   ctx: Context<{}, "request" | "params">
-): Promise<ApiResponse<{ signed_url: string }>> {
-  const initial = Date.now()
+): Promise<
+  ApiResponse<{
+    signed_url: string
+    fields: Record<string, string>
+    max_file_size: number
+  }>
+> {
   const userAuth = await withAuth(ctx)
-  const mimetype = "application/json"
-  const ext = extension(mimetype)
-
-  const timeHash = Math.floor(initial / 1000)
-    .toString(16)
-    .toLowerCase()
-  const userHash = userAuth.address.slice(-8).toLowerCase()
-  const filename = userHash + timeHash + ext
-
-  const signedUrlExpireSeconds = 60 * 1000
+  const ext = extension("application/json")
+  const filename = `${randomUUID()}${ext}`
 
   const signedUrl = await retry({ times: 10, delay: 100 }, async () => {
-    const responseUrl = s3.getSignedUrl("putObject", {
-      Bucket: BUCKET_NAME,
-      Key: `${filename}`,
-      Expires: signedUrlExpireSeconds,
-      ContentType: mimetype,
-      ACL: "private",
-      CacheControl: "public, max-age=31536000, immutable",
-      Metadata: {
-        ...userAuth.metadata,
-        address: userAuth.address,
-      },
-    })
+    const presignedPost = s3.createPresignedPost(
+      createReportPostPolicy(userAuth.address, filename)
+    )
 
-    const url = new URL(responseUrl)
-    if (url.searchParams.size === 0) {
+    const url = new URL(presignedPost.url)
+    if (!presignedPost.fields.Policy) {
       throw new Error("Invalid AWS response")
     }
 
@@ -61,10 +78,15 @@ export async function getSignedUrl(
       url.hostname = BUCKET_HOSTNAME
     }
 
-    return url.toString()
+    return {
+      url: url.toString(),
+      fields: presignedPost.fields,
+    }
   })
 
   return new ApiResponse({
-    signed_url: signedUrl,
+    signed_url: signedUrl.url,
+    fields: signedUrl.fields,
+    max_file_size: REPORT_MAX_FILE_SIZE,
   })
 }

--- a/src/entities/World/routes/index.ts
+++ b/src/entities/World/routes/index.ts
@@ -1,4 +1,3 @@
-import withCors from "decentraland-gatsby/dist/entities/Route/middleware/withCors"
 import routes from "decentraland-gatsby/dist/entities/Route/wkc/routes"
 import env from "decentraland-gatsby/dist/utils/env"
 
@@ -11,16 +10,10 @@ import { updateWorldHighlight } from "./updateWorldHighlight"
 import { updateWorldLikes } from "./updateWorldLikes"
 import { updateWorldRanking } from "./updateWorldRanking"
 import { updateWorldRating } from "./updateWorldRating"
-import { API_CORS_ORIGINS } from "../../shared/cors"
 
 export const DECENTRALAND_URL = env("DECENTRALAND_URL", "")
 
 export default routes((router) => {
-  router.getRouter().use(
-    withCors({
-      corsOrigin: API_CORS_ORIGINS,
-    })
-  )
   router.get("/worlds/:world_id", getWorld)
   router.get("/worlds", getWorldList)
   router.get("/world_names", getWorldNamesList)

--- a/src/entities/World/routes/index.ts
+++ b/src/entities/World/routes/index.ts
@@ -11,25 +11,14 @@ import { updateWorldHighlight } from "./updateWorldHighlight"
 import { updateWorldLikes } from "./updateWorldLikes"
 import { updateWorldRanking } from "./updateWorldRanking"
 import { updateWorldRating } from "./updateWorldRating"
+import { API_CORS_ORIGINS } from "../../shared/cors"
 
 export const DECENTRALAND_URL = env("DECENTRALAND_URL", "")
 
 export default routes((router) => {
   router.getRouter().use(
     withCors({
-      corsOrigin: [
-        /https?:\/\/localhost(:\d{4,6})?/,
-        /https?:\/\/127\.0\.0\.1(:\d{4,6})?/,
-        /https?:\/\/192\.168\.\d{1,3}\.\d{1,3}(:\d{4,6})?/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*dcl\.gg/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.systems/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.today/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.zone/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*decentraland\.org/,
-        /https:\/\/decentraland\.github\.io/,
-        /https:\/\/([a-zA-Z0-9\-_]+\.)*pages\.dev/,
-        /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
-      ],
+      corsOrigin: API_CORS_ORIGINS,
     })
   )
   router.get("/worlds/:world_id", getWorld)

--- a/src/entities/shared/cors.test.ts
+++ b/src/entities/shared/cors.test.ts
@@ -1,0 +1,31 @@
+import { API_CORS_ORIGINS } from "./cors"
+
+function isAllowed(origin: string): boolean {
+  return API_CORS_ORIGINS.some((candidate) => candidate.test(origin))
+}
+
+describe("API CORS origins", () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe.each([
+    "https://decentraland.org.attacker.example",
+    "https://foo.decentraland.org.attacker.example",
+    "https://trusted.pages.dev.attacker.example",
+  ])("when the origin is %s", (origin) => {
+    it("should reject the origin", () => {
+      expect(isAllowed(origin)).toBe(false)
+    })
+  })
+
+  describe.each([
+    "https://decentraland.org",
+    "https://events.decentraland.org",
+    "https://trusted.pages.dev",
+  ])("when the origin is %s", (origin) => {
+    it("should allow the origin", () => {
+      expect(isAllowed(origin)).toBe(true)
+    })
+  })
+})

--- a/src/entities/shared/cors.test.ts
+++ b/src/entities/shared/cors.test.ts
@@ -23,6 +23,7 @@ describe("API CORS origins", () => {
   describe.each([
     "https://decentraland.org",
     "https://events.decentraland.org",
+    "https://dcl-preview.vercel.app",
     "https://places-decentraland1.vercel.app",
   ])("when the origin is %s", (origin) => {
     it("should allow the origin", () => {

--- a/src/entities/shared/cors.test.ts
+++ b/src/entities/shared/cors.test.ts
@@ -13,6 +13,7 @@ describe("API CORS origins", () => {
     "https://decentraland.org.attacker.example",
     "https://foo.decentraland.org.attacker.example",
     "https://trusted.pages.dev.attacker.example",
+    "https://trusted.pages.dev",
   ])("when the origin is %s", (origin) => {
     it("should reject the origin", () => {
       expect(isAllowed(origin)).toBe(false)
@@ -22,7 +23,7 @@ describe("API CORS origins", () => {
   describe.each([
     "https://decentraland.org",
     "https://events.decentraland.org",
-    "https://trusted.pages.dev",
+    "https://places-decentraland1.vercel.app",
   ])("when the origin is %s", (origin) => {
     it("should allow the origin", () => {
       expect(isAllowed(origin)).toBe(true)

--- a/src/entities/shared/cors.ts
+++ b/src/entities/shared/cors.ts
@@ -8,5 +8,6 @@ export const API_CORS_ORIGINS: RegExp[] = [
   /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.zone$/,
   /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.org$/,
   /^https:\/\/decentraland\.github\.io$/,
+  /^https:\/\/dcl-preview\.vercel\.app$/,
   /^https:\/\/[a-zA-Z0-9_-]+-decentraland1\.vercel\.app$/,
 ]

--- a/src/entities/shared/cors.ts
+++ b/src/entities/shared/cors.ts
@@ -1,0 +1,13 @@
+export const API_CORS_ORIGINS: RegExp[] = [
+  /^https?:\/\/localhost(?::\d{4,6})?$/,
+  /^https?:\/\/127\.0\.0\.1(?::\d{4,6})?$/,
+  /^https?:\/\/192\.168\.\d{1,3}\.\d{1,3}(?::\d{4,6})?$/,
+  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*dcl\.gg$/,
+  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.systems$/,
+  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.today$/,
+  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.zone$/,
+  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.org$/,
+  /^https:\/\/decentraland\.github\.io$/,
+  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*pages\.dev$/,
+  /^https:\/\/[a-zA-Z0-9_-]+-decentraland1\.vercel\.app$/,
+]

--- a/src/entities/shared/cors.ts
+++ b/src/entities/shared/cors.ts
@@ -8,6 +8,5 @@ export const API_CORS_ORIGINS: RegExp[] = [
   /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.zone$/,
   /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*decentraland\.org$/,
   /^https:\/\/decentraland\.github\.io$/,
-  /^https:\/\/(?:[a-zA-Z0-9_-]+\.)*pages\.dev$/,
   /^https:\/\/[a-zA-Z0-9_-]+-decentraland1\.vercel\.app$/,
 ]

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import placeRoute from "./entities/Place/routes"
 import { checkPoisForCategoryUpdate } from "./entities/PlaceCategories/tasks/poi"
 import { hotScenesUpdate } from "./entities/RealmProvider/tasks/hotScenesUpdate"
 import reportRoute from "./entities/Report/routes"
+import { API_CORS_ORIGINS } from "./entities/shared/cors"
 import socialRoutes from "./entities/Social/routes"
 import userFavoriteRoute from "./entities/UserFavorite/routes"
 import userLikesRoute from "./entities/UserLikes/routes"
@@ -62,12 +63,7 @@ app.set("x-powered-by", false)
 app.use(withLogs())
 app.use("/api", [
   withCors({
-    corsOrigin: [
-      /^http:\/\/localhost:[0-9]{1,10}$/,
-      /^https:\/\/(.{1,50}\.)?decentraland\.(zone|today|org)$/,
-      /https:\/\/dcl-preview\.vercel\.app/,
-      /https:\/\/([a-zA-Z0-9\-_])+-decentraland1\.vercel\.app/,
-    ],
+    corsOrigin: API_CORS_ORIGINS,
     allowedHeaders: "*",
   }),
   withBody(),


### PR DESCRIPTION
## Summary

- replace report signed PUT URLs with 60-second constrained S3 POST policies
- enforce JSON content, private ACL, unpredictable keys, and a 1 MiB upload limit
- anchor and centralize API CORS origin rules
- make rating changes and audit insertion atomic and awaited
- exclude environment files from container build contexts and update vulnerable dependency resolutions
- document the report upload contract change

## Client migration

POST /api/report now returns signed_url, fields, and max_file_size. Clients must submit a multipart POST to signed_url with every returned field and the JSON report as the file part.

## Validation

- npm run build
- changed-file ESLint
- 39 source unit suites passed: 331 tests passed, 1 skipped
- OpenAPI YAML and Postman JSON parse successfully
- git diff --check
- npm audit reports zero critical vulnerabilities

Integration tests were not run because no local PostgreSQL CONNECTION_STRING was configured.